### PR TITLE
Feature/7 coverage report

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,40 @@
+# CircleCI Configuration
+## Environment Variables
+There is a minimum acceptable percentage for unit test code coverage that defaults to 85%. 
+You can modify this minimum by setting the MIN_COVERAGE_PERCENT environment variable to a 
+different value.
+
+# Using CircleCI local CLI
+
+## Install circleci local
+Install on Linux or Mac with:
+```
+curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
+```
+
+Details and instructions for other platforms in the [CircleCI Docs](https://circleci.com/docs/2.0/local-cli/)
+
+## Validate the config.yml
+Run this from the top level of the repo:
+```
+circleci config validate
+```
+
+## Run the CircleCI Job locally
+You can run a CircleCI job locally and avoid the change/commit/wait loop you need to
+do if you want to actually run the changes on Circle.
+This can save a lot of time when trying to debug an issue in CI.
+```
+circleci local execute --job JOB_NAME
+```
+
+##  Environment Variables
+To run in the local CircleCI with specific environment variables, use the following pattern:
+
+```
+circleci local execute -e MIN_COVERAGE_PERCENT=15 --job unit-test
+```
+
+## CircleCI configuration
+To get CircleCI to run tests, you have to configure the
+project in the Circle web applicaiton https://app.circleci.com/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
+  python: circleci/python@1.2
+
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  unit-test:
+    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
+    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
+    docker:
+      - image: cimg/python:3.8
+
+    steps:
+      - checkout
+
+      - python/install-packages:
+          pkg-manager: pip
+          pip-dependency-file: requirements.txt
+
+      - run:
+          name: Run tests
+          # This assumes pytest is installed via the install-package step above
+          command: pytest
+
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  sample:
+    jobs:
+      - unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,28 @@ jobs:
           pip-dependency-file: requirements.txt
 
       - run:
-          name: Run tests
-          # This assumes pytest is installed via the install-package step above
-          command: pytest --cov=. --cov-report=html
+          name: Run tests, save a coverage report, and save coverage percentage
+          command: |
+            export NEW_PERCENT=$(pytest --cov=. --cov-report=html --cov-report=term | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
+            echo ${NEW_PERCENT} > htmlcov/total_percent.txt
+            echo Total code coverage percentage is ${NEW_PERCENT}%
 
       - store_artifacts:
           path: htmlcov
+
+      - run:
+          name: Run tests, save a coverage report, and save coverage percentage
+          command: |
+            export NEW_PERCENT=$(cat htmlcov/total_percent.txt)
+            echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
+            if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
+              echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%
+              echo If you would like to modify the minimum coverage, set the MIN_COVERAGE_PERCENT environment variable
+              exit 1
+            fi
+            echo Coverage is good.
+
+
 
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,10 @@ jobs:
       - run:
           name: Run tests
           # This assumes pytest is installed via the install-package step above
-          command: pytest
+          command: pytest --cov=. --cov-report=html
+
+      - store_artifacts:
+          path: htmlcov
 
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           path: htmlcov
 
       - run:
-          name: Run tests, save a coverage report, and save coverage percentage
+          name: Compare the actual code coverage to the minimum target coverage
           command: |
             export NEW_PERCENT=$(cat htmlcov/total_percent.txt)
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ jobs:
       - run:
           name: Run tests, save a coverage report, and save coverage percentage
           command: |
-            export NEW_PERCENT=$(pytest --cov=. --cov-report=html --cov-report=term | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
+            pytest --cov=. --cov-report=html --cov-report=term | tee pytest.out
+            export NEW_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
             echo ${NEW_PERCENT} > htmlcov/total_percent.txt
             echo Total code coverage percentage is ${NEW_PERCENT}%
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==1.0.0
 Flask-RESTful==0.3.5
 pytest
+pytest-cov
 psycopg2-binary==2.8.2
 retrying==1.3.3
 gunicorn==19.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.0.0
 Flask-RESTful==0.3.5
-pytest==3.0.7
+pytest
 psycopg2-binary==2.8.2
 retrying==1.3.3
 gunicorn==19.9.0

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,6 @@
+from api.validate import check_null_value
+
+
+def test_check_null_value():
+    assert check_null_value(7) == 7
+    assert check_null_value("null") is None


### PR DESCRIPTION
* Generate an HTML code coverage report in CircleCI and store it as an artifact
* Compare the total coverage to a target (configurable with the MIN_COVERAGE_PERCENT env variable) and **_fail the build if it is too low_**
* Added .circleci/README.md with instructions on CircleCI setup and local run instructions

NOTE: this branch is based on the feature/4-ci-unit-test branch since it adds functionality to that. We should have an easier time in the merge if that pull #9 is approved first.