### PR TITLE
Added flake8 lint test to the CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,10 @@ jobs:
           key: v1-sonarcloud-scanner-4.6.2.2472
           paths: /tmp/cache/scanner
 
+      - run:
+          name: flake8 lint tests
+          command: flake8 .
+
   dependency-check:
     docker:
       - image: cimg/python:3.8


### PR DESCRIPTION
Restored the flake8 lint test to help with QASP metric gathering.