### PR TITLE
Add unit tests to cover number type requirements

### DIFF
--- a/fecfile_validate_js/tests/offset_to_opex.test.ts
+++ b/fecfile_validate_js/tests/offset_to_opex.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from 'https://deno.land/std/testing/asserts.ts';
+import { validate } from '../dist/index.js';
+import { schema } from '../dist/OFFSET_TO_OPEX.js';
+
+const perfectForm: any = {
+  form_type: 'SA15',
+  filer_committee_id_number: 'C00123456',
+  transaction_type_identifier: 'OFFSET_TO_OPEX',
+  transaction_id: 'A12345678',
+  back_reference_tran_id_number: null,
+  back_reference_sched_name: null,
+  entity_type: 'IND',
+  contributor_organization_name: null,
+  contributor_last_name: 'Smith',
+  contributor_first_name: 'Bob',
+  contributor_middle_name: null,
+  contributor_prefix: null,
+  contributor_suffix: null,
+  contributor_street_1: '123 main street',
+  contributor_street_2: '',
+  contributor_city: 'Best Town',
+  contributor_state: 'DC',
+  contributor_zip: '20000',
+  contribution_date: '20220915',
+  contribution_amount: 500,
+  contribution_aggregate: 0,
+  contribution_purpose_descrip: 'a description',
+  memo_code: false,
+  memo_text_description: 'memo text description'
+};
+
+Deno.test({
+  name: 'it should pass with perfect data',
+  fn: () => {
+    const result = validate(schema, perfectForm);
+    assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: 'it should fail if contribution_amount is null',
+  fn: () => {
+    const thisData = { ...perfectForm };
+    thisData.contribution_amount = null;
+    const result = validate(schema, thisData);
+    assertEquals(result[0].keyword, 'type');
+    assertEquals(result[0].path, 'contribution_amount');
+    assertEquals(result[0].params.type, 'number');
+  },
+});
+
+Deno.test({
+  name: 'it should be contributor_organization_name is required for ORG and contributor_first_name not required',
+  fn: () => {
+    const thisData = { ...perfectForm };
+    thisData.entity_type = 'ORG';
+    thisData.contributor_first_name = null;
+    const result = validate(schema, thisData);
+    assertEquals(result[0].keyword, 'type');
+    assertEquals(result[0].path, 'contributor_organization_name');
+    assertEquals(result[0].params.type, 'string');
+    assertEquals(result[1].keyword, 'if');
+  },
+});
+

--- a/schema/OFFSET_TO_OPEX.json
+++ b/schema/OFFSET_TO_OPEX.json
@@ -473,7 +473,10 @@
         {
             "if": {
                 "properties": {
-                    "entity_type": { "pattern": "^(ORG|COM)$" }
+                    "entity_type": {
+                        "type": "string",
+                        "pattern": "^(ORG|COM)$"
+                    }
                 },
                 "required": ["entity_type"]
             },
@@ -485,7 +488,10 @@
         {
             "if": {
                 "properties": {
-                    "entity_type": { "pattern": "^(IND|CAN)$" }
+                    "entity_type": {
+                        "type": "string",
+                        "pattern": "^(IND|CAN)$"
+                    }
                 },
                 "required": ["entity_type"]
             },


### PR DESCRIPTION
Increased unit test coverage and eliminated warning coming from OFFSET_TO_OFFEX schema.

Work related to [app#230](https://github.com/fecgov/fecfile-web-app/issues/230)