### PR TITLE
61 updated schema files to allow special chars in text fields

### DIFF
--- a/fecfile_validate_js/tests/contact_individual.test.ts
+++ b/fecfile_validate_js/tests/contact_individual.test.ts
@@ -1,0 +1,67 @@
+import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { validate } from "../dist/index.js";
+import { schema } from "../dist/Contact_Individual.js";
+
+const perfectForm: any = {
+  type: "IND",
+  last_name: "Smith",
+  first_name: "John",
+  middle_name: "W",
+  prefix: "Dr",
+  suffix: "Jr",
+  street_1: "123 Main Street",
+  street_2: "Test street 2",
+  city: "Anytown",
+  state: "WA",
+  zip: "981110123",
+  telephone: "5555555555",
+  employer: "XYZ Company",
+  occupation: "QC Inspector",
+  country: "United States",
+};
+
+Deno.test({
+  name: "it should pass with perfect data",
+  fn: () => {
+    const result = validate(schema, perfectForm);
+    assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: "it should pass containing every allowed character",
+  fn: () => {
+    const thisData = { ...perfectForm };
+    const specialChars = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    thisData.last_name = specialChars.substring(0, 29);
+    thisData.first_name = specialChars.substring(29, 48);
+    thisData.middle_name = specialChars.substring(48, 67);
+    thisData.street_1 = specialChars.substring(67);
+    const result = validate(schema, thisData);
+    
+    assertEquals(thisData.last_name + thisData.first_name + 
+      thisData.middle_name + thisData.street_1, specialChars);    
+    assertEquals(result, []);
+  },
+});
+
+Deno.test({
+  name: "it should fail containing disallowed character (tab) in last_name",
+  fn: () => {
+    const thisData = { ...perfectForm };
+    const disallowedChar = "\t";
+    const specialChars = disallowedChar + " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    thisData.last_name = specialChars.substring(0, 29);
+    thisData.first_name = specialChars.substring(29, 48);
+    thisData.middle_name = specialChars.substring(48, 67);
+    thisData.street_1 = specialChars.substring(67);
+    assertEquals(thisData.last_name + thisData.first_name + 
+      thisData.middle_name + thisData.street_1, specialChars);    
+    const result = validate(schema, thisData);
+
+    assertEquals(result[0].keyword, "pattern");
+    assertEquals(result[0].message, "must match pattern \"^[ -~]{0,30}$\"");
+    assertEquals(result[0].params.pattern, "^[ -~]{0,30}$");
+    assertEquals(result[0].path, "last_name");
+  },
+});

--- a/schema/BUS_LAB_NON_CONT_ACC.json
+++ b/schema/BUS_LAB_NON_CONT_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "BUS_LAB_CAREY"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/Contact_Candidate.json
+++ b/schema/Contact_Candidate.json
@@ -66,7 +66,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Smith"],
             "fec_spec": {
                 "COL_SEQ": 3,
@@ -86,7 +86,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["John"],
             "fec_spec": {
                 "COL_SEQ": 4,
@@ -106,7 +106,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["W"],
             "fec_spec": {
                 "COL_SEQ": 5,
@@ -126,7 +126,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Dr"],
             "fec_spec": {
                 "COL_SEQ": 6,
@@ -146,7 +146,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Jr"],
             "fec_spec": {
                 "COL_SEQ": 7,
@@ -166,7 +166,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["123 Main Street"],
             "fec_spec": {
                 "COL_SEQ": 8,
@@ -186,7 +186,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 9,
                 "FIELD_DESCRIPTION": "STREET  2",
@@ -205,7 +205,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Anytown"],
             "fec_spec": {
                 "COL_SEQ": 10,
@@ -245,7 +245,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [981110123],
             "fec_spec": {
                 "COL_SEQ": 12,
@@ -265,7 +265,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["XYZ Company"],
             "fec_spec": {
                 "COL_SEQ": 13,
@@ -285,7 +285,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["QC Inspector"],
             "fec_spec": {
                 "COL_SEQ": 14,

--- a/schema/Contact_Committee.json
+++ b/schema/Contact_Committee.json
@@ -51,7 +51,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 200,
-            "pattern": "^[ A-Za-z0-9]{0,200}$",
+            "pattern": "^[ -~]{0,200}$",
             "examples": ["SEIU COPE (Service Employees International Union Committee On Political Education)"],
             "fec_spec": {
                 "COL_SEQ": 3,
@@ -71,7 +71,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["123 Main Street"],
             "fec_spec": {
                 "COL_SEQ": 4,
@@ -91,7 +91,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 5,
                 "FIELD_DESCRIPTION": "STREET  2",
@@ -110,7 +110,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Anytown"],
             "fec_spec": {
                 "COL_SEQ": 6,
@@ -130,7 +130,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["WA"],
             "fec_spec": {
                 "COL_SEQ": 7,
@@ -150,7 +150,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [981110123],
             "fec_spec": {
                 "COL_SEQ": 8,

--- a/schema/Contact_Individual.json
+++ b/schema/Contact_Individual.json
@@ -31,7 +31,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Smith"],
             "fec_spec": {
                 "COL_SEQ": 2,
@@ -51,7 +51,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["John"],
             "fec_spec": {
                 "COL_SEQ": 3,
@@ -71,7 +71,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["W"],
             "fec_spec": {
                 "COL_SEQ": 4,
@@ -91,7 +91,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Dr"],
             "fec_spec": {
                 "COL_SEQ": 5,
@@ -111,7 +111,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Jr"],
             "fec_spec": {
                 "COL_SEQ": 6,
@@ -131,7 +131,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["123 Main Street"],
             "fec_spec": {
                 "COL_SEQ": 7,
@@ -151,7 +151,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 8,
                 "FIELD_DESCRIPTION": "STREET  2",
@@ -170,7 +170,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Anytown"],
             "fec_spec": {
                 "COL_SEQ": 9,
@@ -190,7 +190,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["WA"],
             "fec_spec": {
                 "COL_SEQ": 10,
@@ -210,7 +210,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [981110123],
             "fec_spec": {
                 "COL_SEQ": 11,
@@ -249,7 +249,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["XYZ Company"],
             "fec_spec": {
                 "COL_SEQ": 13,
@@ -269,7 +269,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["QC Inspector"],
             "fec_spec": {
                 "COL_SEQ": 14,

--- a/schema/Contact_Organization.json
+++ b/schema/Contact_Organization.json
@@ -31,7 +31,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 200,
-            "pattern": "^[ A-Za-z0-9]{0,200}$",
+            "pattern": "^[ -~]{0,200}$",
             "examples": ["John Smith & Co."],
             "fec_spec": {
                 "COL_SEQ": 8,
@@ -51,7 +51,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["123 Main Street"],
             "fec_spec": {
                 "COL_SEQ": 14,
@@ -71,7 +71,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 15,
                 "FIELD_DESCRIPTION": "STREET  2",
@@ -90,7 +90,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Anytown"],
             "fec_spec": {
                 "COL_SEQ": 16,
@@ -110,7 +110,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["WA"],
             "fec_spec": {
                 "COL_SEQ": 17,
@@ -130,7 +130,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [981110123],
             "fec_spec": {
                 "COL_SEQ": 18,

--- a/schema/EAR_MEMO.json
+++ b/schema/EAR_MEMO.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -57,7 +57,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -78,7 +78,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": [
         "EAR_MEM_23"
       ],
@@ -99,7 +99,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -123,7 +123,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -147,7 +147,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -303,7 +303,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -324,7 +324,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -348,7 +348,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -492,7 +492,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -510,7 +510,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -528,7 +528,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -549,7 +549,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -570,7 +570,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -594,7 +594,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -615,7 +615,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -633,7 +633,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_MEM"
       ],
@@ -657,7 +657,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": [
         "H"
       ],
@@ -681,7 +681,7 @@
       ],
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "FL"
       ],
@@ -725,7 +725,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -746,7 +746,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/EAR_REC.json
+++ b/schema/EAR_REC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EARMARK_REC"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/EAR_REC_CONVEN_ACC.json
+++ b/schema/EAR_REC_CONVEN_ACC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_RECNT"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/EAR_REC_HQ_ACC.json
+++ b/schema/EAR_REC_HQ_ACC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_RECNT"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/EAR_REC_RECNT_ACC.json
+++ b/schema/EAR_REC_RECNT_ACC.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_RECNT"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -120,7 +120,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -144,7 +144,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -231,7 +231,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -324,7 +324,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -342,7 +342,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -546,7 +546,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/F3X.json
+++ b/schema/F3X.json
@@ -196,7 +196,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 3,
-            "pattern": "^[ A-Za-z0-9]{0,3}$",
+            "pattern": "^[ -~]{0,3}$",
             "examples": ["12P"],
             "fec_spec": {
                 "COL_SEQ": 10,
@@ -215,7 +215,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 5,
-            "pattern": "^[ A-Za-z0-9]{0,5}$",
+            "pattern": "^[ -~]{0,5}$",
             "examples": ["P2012"],
             "fec_spec": {
                 "COL_SEQ": 11,

--- a/schema/INDV_REC.json
+++ b/schema/INDV_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -83,7 +83,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -102,7 +102,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -121,7 +121,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -156,7 +156,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -175,7 +175,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -194,7 +194,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -213,7 +213,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -232,7 +232,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -251,7 +251,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -270,7 +270,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -307,7 +307,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -326,7 +326,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -400,7 +400,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -418,7 +418,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -437,7 +437,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -471,7 +471,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/IND_NP_CONVEN_ACC.json
+++ b/schema/IND_NP_CONVEN_ACC.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_JF_MEM"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -120,7 +120,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -144,7 +144,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -231,7 +231,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -324,7 +324,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -342,7 +342,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -546,7 +546,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/IND_NP_HQ_ACC.json
+++ b/schema/IND_NP_HQ_ACC.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_JF_MEM"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -120,7 +120,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -144,7 +144,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -231,7 +231,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -324,7 +324,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -342,7 +342,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -546,7 +546,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/IND_NP_RECNT_ACC.json
+++ b/schema/IND_NP_RECNT_ACC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_RECNT"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/IND_RECNT_REC.json
+++ b/schema/IND_RECNT_REC.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_JF_MEM"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -120,7 +120,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -144,7 +144,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -231,7 +231,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -324,7 +324,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -342,7 +342,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -546,7 +546,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/IND_REC_NON_CONT_ACC.json
+++ b/schema/IND_REC_NON_CONT_ACC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_CAREY"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN.json
+++ b/schema/JF_TRAN.json
@@ -46,7 +46,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -109,7 +109,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -133,7 +133,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -172,7 +172,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -193,7 +193,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -217,7 +217,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -235,7 +235,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -277,7 +277,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -376,7 +376,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -397,7 +397,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -421,7 +421,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_IND_MEMO.json
+++ b/schema/JF_TRAN_IND_MEMO.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_JF_MEM"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -120,7 +120,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -144,7 +144,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -231,7 +231,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -255,7 +255,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -279,7 +279,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -324,7 +324,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -342,7 +342,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -546,7 +546,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_CONVEN_ACC.json
+++ b/schema/JF_TRAN_NP_CONVEN_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "JF_TRAN"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_PAC_REC"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_HQ_ACC.json
+++ b/schema/JF_TRAN_NP_HQ_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "JF_TRAN"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -455,7 +455,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_PAC_REC"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_RECNT_ACC.json
+++ b/schema/JF_TRAN_NP_RECNT_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "JF_TRAN"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_PAC_REC"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_PAC_MEMO.json
+++ b/schema/JF_TRAN_PAC_MEMO.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_PARTY_MEMO.json
+++ b/schema/JF_TRAN_PARTY_MEMO.json
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -111,7 +111,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -213,7 +213,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -252,7 +252,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -273,7 +273,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -354,7 +354,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -375,7 +375,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 25,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -396,7 +396,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -417,7 +417,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -438,7 +438,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/JF_TRAN_TRIB_MEMO.json
+++ b/schema/JF_TRAN_TRIB_MEMO.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -408,7 +408,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/OFFSET_TO_OPEX.json
+++ b/schema/OFFSET_TO_OPEX.json
@@ -27,7 +27,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA15"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -46,7 +46,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -81,7 +81,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -100,7 +100,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -119,7 +119,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -154,7 +154,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -173,7 +173,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -192,7 +192,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -211,7 +211,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -230,7 +230,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -249,7 +249,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -268,7 +268,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -287,7 +287,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -305,7 +305,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -324,7 +324,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -343,7 +343,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -417,7 +417,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -450,7 +450,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/OTH_CMTE_NON_CONT_ACC.json
+++ b/schema/OTH_CMTE_NON_CONT_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "OTHER_COM_CAREY"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -455,7 +455,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/OTH_REC.json
+++ b/schema/OTH_REC.json
@@ -43,7 +43,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -78,7 +78,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -97,7 +97,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -116,7 +116,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -151,7 +151,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -170,7 +170,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -189,7 +189,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -208,7 +208,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -227,7 +227,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -246,7 +246,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -284,7 +284,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -302,7 +302,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -321,7 +321,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -340,7 +340,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -414,7 +414,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -432,7 +432,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -451,7 +451,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -485,7 +485,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_EAR_MEMO.json
+++ b/schema/PAC_EAR_MEMO.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_REC_MEM"
       ],
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -118,7 +118,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -142,7 +142,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -205,7 +205,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -229,7 +229,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -247,7 +247,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -268,7 +268,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -370,7 +370,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -430,7 +430,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -451,7 +451,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_EAR_REC.json
+++ b/schema/PAC_EAR_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "EAR_PAC_REC"
       ],
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -118,7 +118,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -142,7 +142,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -205,7 +205,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -229,7 +229,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -247,7 +247,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -268,7 +268,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -370,7 +370,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -430,7 +430,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -451,7 +451,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_NON_FED_REC.json
+++ b/schema/PAC_NON_FED_REC.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_REC"
       ],
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -115,7 +115,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -139,7 +139,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -226,7 +226,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -286,7 +286,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -370,7 +370,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -391,7 +391,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -412,7 +412,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_NON_FED_RET.json
+++ b/schema/PAC_NON_FED_RET.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_RET"
       ],
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -115,7 +115,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -139,7 +139,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -226,7 +226,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -286,7 +286,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -370,7 +370,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -391,7 +391,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -412,7 +412,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_NP_CONVEN_ACC.json
+++ b/schema/PAC_NP_CONVEN_ACC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_NP_HQ_ACC.json
+++ b/schema/PAC_NP_HQ_ACC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -411,7 +411,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_NP_RECNT_ACC.json
+++ b/schema/PAC_NP_RECNT_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PTY_RCNT"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -455,7 +455,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_REC.json
+++ b/schema/PAC_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_REC"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -372,7 +372,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_RECNT_REC.json
+++ b/schema/PAC_RECNT_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PTY_RCNT"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -455,7 +455,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PAC_RET.json
+++ b/schema/PAC_RET.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_RET"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -372,7 +372,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PARTN_MEMO.json
+++ b/schema/PARTN_MEMO.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAR_MEMO"
       ],
@@ -98,7 +98,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -251,7 +251,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -275,7 +275,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -296,7 +296,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -320,7 +320,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -338,7 +338,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -359,7 +359,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -380,7 +380,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -461,7 +461,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -479,7 +479,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -500,7 +500,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -521,7 +521,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -542,7 +542,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PARTY_NP_RECNT_ACC.json
+++ b/schema/PARTY_NP_RECNT_ACC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "IND_RECNT"
       ],
@@ -95,7 +95,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -119,7 +119,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -143,7 +143,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -230,7 +230,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -254,7 +254,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -278,7 +278,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -323,7 +323,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -527,7 +527,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -548,7 +548,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PARTY_REC.json
+++ b/schema/PARTY_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAR_REC"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -372,7 +372,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -390,7 +390,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -432,7 +432,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -453,7 +453,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PARTY_RECNT_REC.json
+++ b/schema/PARTY_RECNT_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PTY_RCNT"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -434,7 +434,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -455,7 +455,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/PARTY_RET.json
+++ b/schema/PARTY_RET.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAR_RET"
       ],
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -115,7 +115,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -139,7 +139,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -226,7 +226,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -286,7 +286,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -370,7 +370,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -391,7 +391,7 @@
       ],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -412,7 +412,7 @@
       ],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "Action PAC"
       ],
@@ -436,7 +436,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -457,7 +457,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/REATT_FROM.json
+++ b/schema/REATT_FROM.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "REATT_FROM"
       ],
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -121,7 +121,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -146,7 +146,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -212,7 +212,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -237,7 +237,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -262,7 +262,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -287,7 +287,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -334,7 +334,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -353,7 +353,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -375,7 +375,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -397,7 +397,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -488,7 +488,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -507,7 +507,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -529,7 +529,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -554,7 +554,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -576,7 +576,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/REATT_TO.json
+++ b/schema/REATT_TO.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "REATT_TO"
       ],
@@ -97,7 +97,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -122,7 +122,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -147,7 +147,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -191,7 +191,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -213,7 +213,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -238,7 +238,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -263,7 +263,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -288,7 +288,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -310,7 +310,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -335,7 +335,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -354,7 +354,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -376,7 +376,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -398,7 +398,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -486,7 +486,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -527,7 +527,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -552,7 +552,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -574,7 +574,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/RET_REC.json
+++ b/schema/RET_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "RET_REC"
       ],
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -118,7 +118,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -142,7 +142,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Smith"
       ],
@@ -205,7 +205,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "John"
       ],
@@ -229,7 +229,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "W"
       ],
@@ -253,7 +253,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Dr"
       ],
@@ -277,7 +277,7 @@
       ],
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": [
         "Jr"
       ],
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -322,7 +322,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -340,7 +340,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -361,7 +361,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -382,7 +382,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -466,7 +466,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -484,7 +484,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "XYZ Company"
       ],
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": [
         "QC Inspector"
       ],
@@ -529,7 +529,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -550,7 +550,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/SchA.json
+++ b/schema/SchA.json
@@ -29,7 +29,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 8,
-            "pattern": "^[ A-Za-z0-9]{0,8}$",
+            "pattern": "^[ -~]{0,8}$",
             "examples": ["SA11AI"],
             "fec_spec": {
                 "COL_SEQ": 1,
@@ -48,7 +48,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": ["C00123456"],
             "fec_spec": {
                 "COL_SEQ": 2,
@@ -67,7 +67,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["A56123456789-1234"],
             "fec_spec": {
                 "COL_SEQ": 3,
@@ -86,7 +86,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["A123456789-1234"],
             "fec_spec": {
                 "COL_SEQ": 4,
@@ -105,7 +105,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 8,
-            "pattern": "^[ A-Za-z0-9]{0,8}$",
+            "pattern": "^[ -~]{0,8}$",
             "examples": ["SA11AI"],
             "fec_spec": {
                 "COL_SEQ": 5,
@@ -124,7 +124,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 3,
-            "pattern": "^[ A-Za-z0-9]{0,3}$",
+            "pattern": "^[ -~]{0,3}$",
             "examples": ["IND"],
             "fec_spec": {
                 "COL_SEQ": 6,
@@ -143,7 +143,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 200,
-            "pattern": "^[ A-Za-z0-9]{0,200}$",
+            "pattern": "^[ -~]{0,200}$",
             "examples": ["John Smith & Co."],
             "fec_spec": {
                 "COL_SEQ": 7,
@@ -162,7 +162,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Smith"],
             "fec_spec": {
                 "COL_SEQ": 8,
@@ -181,7 +181,7 @@
             "type": "string",
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["John"],
             "fec_spec": {
                 "COL_SEQ": 9,
@@ -200,7 +200,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "examples": ["W"],
             "fec_spec": {
                 "COL_SEQ": 10,
@@ -219,7 +219,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Dr"],
             "fec_spec": {
                 "COL_SEQ": 11,
@@ -238,7 +238,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "examples": ["Jr"],
             "fec_spec": {
                 "COL_SEQ": 12,
@@ -257,7 +257,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["123 Main Street"],
             "fec_spec": {
                 "COL_SEQ": 13,
@@ -276,7 +276,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 14,
                 "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -294,7 +294,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Anytown"],
             "fec_spec": {
                 "COL_SEQ": 15,
@@ -313,7 +313,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["WA"],
             "fec_spec": {
                 "COL_SEQ": 16,
@@ -332,7 +332,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [981110123],
             "fec_spec": {
                 "COL_SEQ": 17,
@@ -351,7 +351,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 5,
-            "pattern": "^[ A-Za-z0-9]{0,5}$",
+            "pattern": "^[ -~]{0,5}$",
             "examples": ["P2012"],
             "fec_spec": {
                 "COL_SEQ": 18,
@@ -370,7 +370,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "fec_spec": {
                 "COL_SEQ": 19,
                 "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -443,7 +443,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 100,
-            "pattern": "^[ A-Za-z0-9]{0,100}$",
+            "pattern": "^[ -~]{0,100}$",
             "fec_spec": {
                 "COL_SEQ": 23,
                 "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -461,7 +461,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["XYZ Company"],
             "fec_spec": {
                 "COL_SEQ": 24,
@@ -480,7 +480,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 38,
-            "pattern": "^[ A-Za-z0-9]{0,38}$",
+            "pattern": "^[ -~]{0,38}$",
             "examples": ["QC Inspector"],
             "fec_spec": {
                 "COL_SEQ": 25,
@@ -499,7 +499,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "fec_spec": {
                 "COL_SEQ": 26,
                 "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -517,7 +517,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 200,
-            "pattern": "^[ A-Za-z0-9]{0,200}$",
+            "pattern": "^[ -~]{0,200}$",
             "examples": ["Action PAC"],
             "fec_spec": {
                 "COL_SEQ": 27,
@@ -536,7 +536,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": ["H98765431"],
             "fec_spec": {
                 "COL_SEQ": 28,
@@ -555,7 +555,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "fec_spec": {
                 "COL_SEQ": 29,
                 "FIELD_DESCRIPTION": "DONOR CANDIDATE LAST NAME",
@@ -573,7 +573,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "fec_spec": {
                 "COL_SEQ": 30,
                 "FIELD_DESCRIPTION": "DONOR CANDIDATE FIRST NAME",
@@ -591,7 +591,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 20,
-            "pattern": "^[ A-Za-z0-9]{0,20}$",
+            "pattern": "^[ -~]{0,20}$",
             "fec_spec": {
                 "COL_SEQ": 31,
                 "FIELD_DESCRIPTION": "DONOR CANDIDATE MIDDLE NAME",
@@ -609,7 +609,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "fec_spec": {
                 "COL_SEQ": 32,
                 "FIELD_DESCRIPTION": "DONOR CANDIDATE PREFIX",
@@ -627,7 +627,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 10,
-            "pattern": "^[ A-Za-z0-9]{0,10}$",
+            "pattern": "^[ -~]{0,10}$",
             "fec_spec": {
                 "COL_SEQ": 33,
                 "FIELD_DESCRIPTION": "DONOR CANDIDATE SUFFIX",
@@ -645,7 +645,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 1,
-            "pattern": "^[ A-Za-z0-9]{0,1}$",
+            "pattern": "^[ -~]{0,1}$",
             "examples": ["H"],
             "fec_spec": {
                 "COL_SEQ": 34,
@@ -664,7 +664,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["FL"],
             "fec_spec": {
                 "COL_SEQ": 35,
@@ -702,7 +702,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 200,
-            "pattern": "^[ A-Za-z0-9]{0,200}$",
+            "pattern": "^[ -~]{0,200}$",
             "examples": ["Middle Organization"],
             "fec_spec": {
                 "COL_SEQ": 37,
@@ -721,7 +721,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "examples": ["45 E Street"],
             "fec_spec": {
                 "COL_SEQ": 38,
@@ -740,7 +740,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 34,
-            "pattern": "^[ A-Za-z0-9]{0,34}$",
+            "pattern": "^[ -~]{0,34}$",
             "fec_spec": {
                 "COL_SEQ": 39,
                 "FIELD_DESCRIPTION": "CONDUIT STREET2",
@@ -758,7 +758,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 30,
-            "pattern": "^[ A-Za-z0-9]{0,30}$",
+            "pattern": "^[ -~]{0,30}$",
             "examples": ["Springfield"],
             "fec_spec": {
                 "COL_SEQ": 40,
@@ -777,7 +777,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 2,
-            "pattern": "^[ A-Za-z0-9]{0,2}$",
+            "pattern": "^[ -~]{0,2}$",
             "examples": ["MA"],
             "fec_spec": {
                 "COL_SEQ": 41,
@@ -796,7 +796,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": [10111],
             "fec_spec": {
                 "COL_SEQ": 42,
@@ -830,7 +830,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 100,
-            "pattern": "^[ A-Za-z0-9]{0,100}$",
+            "pattern": "^[ -~]{0,100}$",
             "fec_spec": {
                 "COL_SEQ": 44,
                 "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -848,7 +848,7 @@
             "type": ["string", "null"],
             "minLength": 0,
             "maxLength": 9,
-            "pattern": "^[ A-Za-z0-9]{0,9}$",
+            "pattern": "^[ -~]{0,9}$",
             "examples": ["123xyzABC"],
             "fec_spec": {
                 "COL_SEQ": 45,

--- a/schema/TRAN.json
+++ b/schema/TRAN.json
@@ -46,7 +46,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -81,7 +81,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -100,7 +100,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -119,7 +119,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -154,7 +154,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -173,7 +173,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -192,7 +192,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -229,7 +229,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -321,7 +321,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -339,7 +339,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -357,7 +357,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -376,7 +376,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -394,7 +394,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/TRIB_NP_CONVEN_ACC.json
+++ b/schema/TRIB_NP_CONVEN_ACC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -408,7 +408,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/TRIB_NP_HQ_ACC.json
+++ b/schema/TRIB_NP_HQ_ACC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PAC_JF_MEM"
       ],
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -117,7 +117,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -141,7 +141,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -228,7 +228,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -408,7 +408,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/TRIB_NP_RECNT_ACC.json
+++ b/schema/TRIB_NP_RECNT_ACC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PTY_RCNT"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/TRIB_REC.json
+++ b/schema/TRIB_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -83,7 +83,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -102,7 +102,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -121,7 +121,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -156,7 +156,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Jo Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -175,7 +175,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -194,7 +194,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -212,7 +212,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -355,7 +355,7 @@
       "type": ["string", "null"],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/TRIB_RECNT_REC.json
+++ b/schema/TRIB_RECNT_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         "C00123456"
       ],
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": [
         "PTY_RCNT"
       ],
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A56123456789-1234"
       ],
@@ -116,7 +116,7 @@
       ],
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": [
         "A123456789-1234"
       ],
@@ -140,7 +140,7 @@
       ],
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": [
         "SA11AI"
       ],
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [
         "IND"
       ],
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "John Smith & Co."
       ],
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": [
         "123 Main Street"
       ],
@@ -227,7 +227,7 @@
       ],
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": [
         "Anytown"
       ],
@@ -266,7 +266,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [
         "WA"
       ],
@@ -287,7 +287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [
         981110123
       ],
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -389,7 +389,7 @@
       ],
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -410,7 +410,7 @@
       ],
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/-1.json
+++ b/schema/backlog/-1.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -55,7 +55,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "TRANSACTION TYPE IDENTIFIER",
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -187,7 +187,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -225,7 +225,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -263,7 +263,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -282,7 +282,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -301,7 +301,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -355,7 +355,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -374,7 +374,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -393,7 +393,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -412,7 +412,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -431,7 +431,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -450,7 +450,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE LAST NAME",
@@ -468,7 +468,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE FIRST NAME",
@@ -486,7 +486,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE MIDDLE NAME",
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE PREFIX",
@@ -522,7 +522,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE SUFFIX",
@@ -540,7 +540,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -559,7 +559,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -596,7 +596,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -614,7 +614,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/-2.json
+++ b/schema/backlog/-2.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "TRANSACTION TYPE IDENTIFIER",
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -226,7 +226,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -264,7 +264,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -302,7 +302,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -356,7 +356,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -375,7 +375,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -394,7 +394,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -413,7 +413,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -451,7 +451,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE LAST NAME",
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE FIRST NAME",
@@ -487,7 +487,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE MIDDLE NAME",
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE PREFIX",
@@ -523,7 +523,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE SUFFIX",
@@ -541,7 +541,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -560,7 +560,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -597,7 +597,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -615,7 +615,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/BC_PREV-2.json
+++ b/schema/backlog/BC_PREV-2.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -270,7 +270,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -484,7 +484,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["BC_PREV"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/BC_PREV.json
+++ b/schema/backlog/BC_PREV.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -270,7 +270,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -484,7 +484,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["BC_PREV"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/BC_TO_IND-2.json
+++ b/schema/backlog/BC_TO_IND-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["ORG"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -325,7 +325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -344,7 +344,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -422,7 +422,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["BC_TO_IND"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/BC_TO_IND.json
+++ b/schema/backlog/BC_TO_IND.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -270,7 +270,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -484,7 +484,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["BC_TO_IND"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/BUS_LAB_CAREY.json
+++ b/schema/backlog/BUS_LAB_CAREY.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["BUS_LAB_CAREY"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/Contact_Candidate.json
+++ b/schema/backlog/Contact_Candidate.json
@@ -44,7 +44,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H01234567"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -64,7 +64,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -84,7 +84,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -243,7 +243,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -263,7 +263,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -321,7 +321,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "CANDIDATE DISTRICT",

--- a/schema/backlog/Contact_Committee.json
+++ b/schema/backlog/Contact_Committee.json
@@ -40,7 +40,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["c01234567"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -60,7 +60,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": [
         "SEIU COPE (Service Employees International Union Committee On Political Education)"
       ],
@@ -82,7 +82,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -102,7 +102,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -121,7 +121,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -141,7 +141,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 8,

--- a/schema/backlog/Contact_Individual.json
+++ b/schema/backlog/Contact_Individual.json
@@ -40,7 +40,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -60,7 +60,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -80,7 +80,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -100,7 +100,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -120,7 +120,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -140,7 +140,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -179,7 +179,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -278,7 +278,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 14,

--- a/schema/backlog/Contact_Organization.json
+++ b/schema/backlog/Contact_Organization.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,

--- a/schema/backlog/EARMARK_REC-2.json
+++ b/schema/backlog/EARMARK_REC-2.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EARMARK_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EARMARK_REC.json
+++ b/schema/backlog/EARMARK_REC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EARMARK_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_MEM-2.json
+++ b/schema/backlog/EAR_MEM-2.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -55,7 +55,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": ["EAR_MEM_23"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -226,7 +226,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -264,7 +264,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -302,7 +302,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -320,7 +320,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -339,7 +339,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -358,7 +358,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -431,7 +431,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -449,7 +449,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -467,7 +467,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -486,7 +486,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -524,7 +524,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -542,7 +542,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -560,7 +560,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_MEM"],
       "fec_spec": {
         "COL_SEQ": 47,
@@ -579,7 +579,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -598,7 +598,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -635,7 +635,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -653,7 +653,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_MEM.json
+++ b/schema/backlog/EAR_MEM.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_PAC_REC-2.json
+++ b/schema/backlog/EAR_PAC_REC-2.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_PAC_REC-3.json
+++ b/schema/backlog/EAR_PAC_REC-3.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_PAC_REC-4.json
+++ b/schema/backlog/EAR_PAC_REC-4.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_PAC_REC.json
+++ b/schema/backlog/EAR_PAC_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_REC_23-2.json
+++ b/schema/backlog/EAR_REC_23-2.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_REC_23"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -113,7 +113,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -132,7 +132,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -151,7 +151,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -284,7 +284,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -303,7 +303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -357,7 +357,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -376,7 +376,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -395,7 +395,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -414,7 +414,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -433,7 +433,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -452,7 +452,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE LAST NAME",
@@ -470,7 +470,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE FIRST NAME",
@@ -488,7 +488,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE MIDDLE NAME",
@@ -506,7 +506,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE PREFIX",
@@ -524,7 +524,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE SUFFIX",
@@ -542,7 +542,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -561,7 +561,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -598,7 +598,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -616,7 +616,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_REC_23.json
+++ b/schema/backlog/EAR_REC_23.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -55,7 +55,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_REC_23"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -226,7 +226,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -264,7 +264,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -302,7 +302,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -356,7 +356,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -375,7 +375,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -394,7 +394,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -413,7 +413,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -451,7 +451,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE LAST NAME",
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE FIRST NAME",
@@ -487,7 +487,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE MIDDLE NAME",
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE PREFIX",
@@ -523,7 +523,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE SUFFIX",
@@ -541,7 +541,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -560,7 +560,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -597,7 +597,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -615,7 +615,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_REC_MEM-2.json
+++ b/schema/backlog/EAR_REC_MEM-2.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_REC_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/EAR_REC_MEM.json
+++ b/schema/backlog/EAR_REC_MEM.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["EAR_REC_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/F1.json
+++ b/schema/backlog/F1.json
@@ -58,7 +58,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["F1N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "STREET 2",
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "examples": ["JSmith@xyz.com;Gsmith@xyz.com"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -292,7 +292,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "examples": ["www.xyz.com"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["A, B, C, D, E, F,G,H"],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -463,7 +463,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -501,7 +501,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -520,7 +520,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -539,7 +539,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -558,7 +558,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -577,7 +577,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -596,7 +596,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 30,
@@ -634,7 +634,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 32,
@@ -653,7 +653,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["NAT"],
       "fec_spec": {
         "COL_SEQ": 33,
@@ -672,7 +672,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["C"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -691,7 +691,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -710,7 +710,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -729,7 +729,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -748,7 +748,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 38,
         "FIELD_DESCRIPTION": "6. AFFILIATED CMTTE ID NUM",
@@ -766,7 +766,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 39,
         "FIELD_DESCRIPTION": "6. AFFILIATED CMTTE NAME",
@@ -784,7 +784,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 40,
         "FIELD_DESCRIPTION": "6. AFFILIATED CANDIDATE ID NUM",
@@ -802,7 +802,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -821,7 +821,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 42,
@@ -840,7 +840,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 43,
@@ -859,7 +859,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 44,
@@ -878,7 +878,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 45,
@@ -897,7 +897,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 46,
         "FIELD_DESCRIPTION": "6. AFFILIATED STREET 1",
@@ -915,7 +915,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 47,
         "FIELD_DESCRIPTION": "6. AFFILIATED STREET 2",
@@ -933,7 +933,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 48,
         "FIELD_DESCRIPTION": "6. AFFILIATED CITY",
@@ -951,7 +951,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 49,
         "FIELD_DESCRIPTION": "6. AFFILIATED STATE",
@@ -969,7 +969,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 50,
         "FIELD_DESCRIPTION": "6. AFFILIATED ZIP",
@@ -987,7 +987,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["AFF"],
       "fec_spec": {
         "COL_SEQ": 51,
@@ -1006,7 +1006,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 52,
@@ -1025,7 +1025,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 53,
@@ -1044,7 +1044,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 54,
@@ -1063,7 +1063,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 55,
@@ -1082,7 +1082,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 56,
@@ -1101,7 +1101,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 57,
         "FIELD_DESCRIPTION": "7. CUSTODIAN STREET 1",
@@ -1119,7 +1119,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 58,
         "FIELD_DESCRIPTION": "7. CUSTODIAN STREET 2",
@@ -1137,7 +1137,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 59,
         "FIELD_DESCRIPTION": "7. CUSTODIAN CITY",
@@ -1155,7 +1155,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 60,
         "FIELD_DESCRIPTION": "7. CUSTODIAN STATE",
@@ -1173,7 +1173,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 61,
         "FIELD_DESCRIPTION": "7. CUSTODIAN ZIP",
@@ -1191,7 +1191,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 62,
         "FIELD_DESCRIPTION": "7. CUSTODIAN TITLE",
@@ -1227,7 +1227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 64,
@@ -1246,7 +1246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 65,
@@ -1265,7 +1265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 66,
@@ -1284,7 +1284,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 67,
@@ -1303,7 +1303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 68,
@@ -1322,7 +1322,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 69,
         "FIELD_DESCRIPTION": "8. TREASURER STREET 1",
@@ -1340,7 +1340,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 70,
         "FIELD_DESCRIPTION": "8. TREASURER STREET 2",
@@ -1358,7 +1358,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 71,
         "FIELD_DESCRIPTION": "8. TREASURER CITY",
@@ -1376,7 +1376,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 72,
         "FIELD_DESCRIPTION": "8. TREASURER STATE",
@@ -1394,7 +1394,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 73,
         "FIELD_DESCRIPTION": "8. TREASURER ZIP",
@@ -1412,7 +1412,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 74,
         "FIELD_DESCRIPTION": "8. TREASURER TITLE",
@@ -1449,7 +1449,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 76,
@@ -1468,7 +1468,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 77,
@@ -1487,7 +1487,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 78,
@@ -1506,7 +1506,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 79,
@@ -1525,7 +1525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 80,
@@ -1544,7 +1544,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 81,
         "FIELD_DESCRIPTION": "8. AGENT STREET 1",
@@ -1562,7 +1562,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 82,
         "FIELD_DESCRIPTION": "8. AGENT STREET 2",
@@ -1580,7 +1580,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 83,
         "FIELD_DESCRIPTION": "8. AGENT CITY",
@@ -1598,7 +1598,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 84,
         "FIELD_DESCRIPTION": "8. AGENT STATE",
@@ -1634,7 +1634,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 86,
         "FIELD_DESCRIPTION": "8. AGENT TITLE",
@@ -1670,7 +1670,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 88,
         "FIELD_DESCRIPTION": "9. a) BANK NAME",
@@ -1688,7 +1688,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 89,
         "FIELD_DESCRIPTION": "9. a) BANK STREET 1",
@@ -1706,7 +1706,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 90,
         "FIELD_DESCRIPTION": "9. a) BANK STREET 2",
@@ -1724,7 +1724,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 91,
         "FIELD_DESCRIPTION": "9. a) BANK CITY",
@@ -1742,7 +1742,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 92,
         "FIELD_DESCRIPTION": "9. a) BANK STATE",
@@ -1760,7 +1760,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 93,
         "FIELD_DESCRIPTION": "9. a) BANK ZIP",
@@ -1778,7 +1778,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 94,
         "FIELD_DESCRIPTION": "9. b) BANK NAME",
@@ -1796,7 +1796,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 95,
         "FIELD_DESCRIPTION": "9. b) BANK STREET 1",
@@ -1814,7 +1814,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 96,
         "FIELD_DESCRIPTION": "9. b) BANK STREET 2",
@@ -1832,7 +1832,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 97,
         "FIELD_DESCRIPTION": "9. b) BANK CITY",
@@ -1850,7 +1850,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 98,
         "FIELD_DESCRIPTION": "9. b) BANK STATE",
@@ -1868,7 +1868,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 99,
         "FIELD_DESCRIPTION": "9. b) BANK ZIP",

--- a/schema/backlog/F13.json
+++ b/schema/backlog/F13.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F13N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Pat Smith Inaugural Committee"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["125 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["90D"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/backlog/F132.json
+++ b/schema/backlog/F132.json
@@ -27,7 +27,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F132"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -46,7 +46,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -65,7 +65,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A1234569-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -84,7 +84,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A3456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -103,7 +103,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F133"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -122,7 +122,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -141,7 +141,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith, Inc"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -179,7 +179,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -198,7 +198,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -292,7 +292,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -311,7 +311,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 21,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -422,7 +422,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 22,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/F133.json
+++ b/schema/backlog/F133.json
@@ -26,7 +26,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F133"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -45,7 +45,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -64,7 +64,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B1234569-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -83,7 +83,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B3456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -102,7 +102,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F132"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -121,7 +121,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -140,7 +140,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith, Inc"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -159,7 +159,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -178,7 +178,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -197,7 +197,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -216,7 +216,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -235,7 +235,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -254,7 +254,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -273,7 +273,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -292,7 +292,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -311,7 +311,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 21,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/F1M.json
+++ b/schema/backlog/F1M.json
@@ -20,7 +20,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F1MN"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -39,7 +39,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -58,7 +58,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -114,7 +114,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -133,7 +133,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -152,7 +152,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -171,7 +171,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -209,7 +209,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "AFFILIATED COMMITTEE FEC ID",
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "AFFILIATED COMMITTEE NAME",
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -264,7 +264,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -302,7 +302,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -321,7 +321,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -340,7 +340,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -359,7 +359,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -378,7 +378,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -435,7 +435,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -454,7 +454,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -473,7 +473,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -492,7 +492,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -511,7 +511,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -530,7 +530,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -549,7 +549,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -568,7 +568,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 30,
@@ -625,7 +625,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 33,
@@ -644,7 +644,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -663,7 +663,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -682,7 +682,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -701,7 +701,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -720,7 +720,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -739,7 +739,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 39,
@@ -758,7 +758,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -815,7 +815,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 43,
@@ -834,7 +834,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 44,
@@ -853,7 +853,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 45,
@@ -872,7 +872,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 46,
@@ -891,7 +891,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 47,
@@ -910,7 +910,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 48,
@@ -929,7 +929,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 49,
@@ -948,7 +948,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 50,
@@ -1005,7 +1005,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 53,
@@ -1024,7 +1024,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 54,
@@ -1043,7 +1043,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 55,
@@ -1062,7 +1062,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 56,
@@ -1081,7 +1081,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 57,
@@ -1100,7 +1100,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 58,
@@ -1119,7 +1119,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 59,
@@ -1138,7 +1138,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 60,
@@ -1249,7 +1249,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 66,
@@ -1268,7 +1268,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 67,
@@ -1287,7 +1287,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 68,
@@ -1306,7 +1306,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 69,
@@ -1325,7 +1325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 70,

--- a/schema/backlog/F1S.json
+++ b/schema/backlog/F1S.json
@@ -14,7 +14,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["F1S"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "5. JOINT FUND PARTICIPANT CMTTE NAME",
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "5. JOINT FUND PARTICIPANT CMTTE FEC-ID",
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "6. AFFILIATED CMTTE ID NUM",
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "6. AFFILIATED CMTTE NAME",
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "6. AFFILIATED CANDIDATE ID NUM",
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "6. AFFILIATED STREET 1",
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "6. AFFILIATED STREET 2",
@@ -273,7 +273,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "6. AFFILIATED CITY",
@@ -291,7 +291,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "6. AFFILIATED STATE",
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "6. AFFILIATED ZIP",
@@ -327,7 +327,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["AFF"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -422,7 +422,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -441,7 +441,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "8. AGENT STREET 1",
@@ -459,7 +459,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 25,
         "FIELD_DESCRIPTION": "8. AGENT STREET 2",
@@ -477,7 +477,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "8. AGENT CITY",
@@ -495,7 +495,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "8. AGENT STATE",
@@ -531,7 +531,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "8. AGENT TITLE",
@@ -567,7 +567,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "9. BANK NAME",
@@ -585,7 +585,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "9. BANK STREET 1",
@@ -603,7 +603,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "9. BANK STREET 2",
@@ -621,7 +621,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 34,
         "FIELD_DESCRIPTION": "9. BANK CITY",
@@ -639,7 +639,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 35,
         "FIELD_DESCRIPTION": "9. BANK STATE",
@@ -657,7 +657,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 36,
         "FIELD_DESCRIPTION": "9. BANK ZIP",

--- a/schema/backlog/F2.json
+++ b/schema/backlog/F2.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F2N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["S04MA3210"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "CANDIDATE LAST NAME",
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "CANDIDATE FIRST NAME",
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "CANDIDATE MIDDLE NAME",
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "CANDIDATE PREFIX",
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "CANDIDATE SUFFIX",
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "VICE PRESIDENT LAST NAME",
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "VICE PRESIDENT FIRST NAME",
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "VICE PRESIDENT MIDDLE NAME",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "VICE PRESIDENT PREFIX",
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "VICE PRESIDENT SUFFIX",
@@ -271,7 +271,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 43,
-      "pattern": "^[ A-Za-z0-9]{0,43}$",
+      "pattern": "^[ -~]{0,43}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "CANDIDATE STREET 1",
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CANDIDATE STREET 2",
@@ -307,7 +307,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "CANDIDATE CITY",
@@ -325,7 +325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -344,7 +344,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -382,7 +382,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -458,7 +458,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "PCC COMMITTEE ID NUMBER",
@@ -476,7 +476,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 25,
         "FIELD_DESCRIPTION": "PCC COMMITTEE NAME",
@@ -494,7 +494,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "PCC STREET 1",
@@ -512,7 +512,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "PCC STREET 2",
@@ -530,7 +530,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 28,
         "FIELD_DESCRIPTION": "PCC CITY",
@@ -548,7 +548,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "PCC STATE",
@@ -566,7 +566,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "PCC ZIP",
@@ -584,7 +584,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "AUTH COMMITTEE ID NUMBER",
@@ -602,7 +602,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "AUTH COMMITTEE NAME",
@@ -620,7 +620,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "AUTH STREET 1",
@@ -638,7 +638,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 34,
         "FIELD_DESCRIPTION": "AUTH STREET 2",
@@ -656,7 +656,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 35,
         "FIELD_DESCRIPTION": "AUTH CITY",
@@ -674,7 +674,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 36,
         "FIELD_DESCRIPTION": "AUTH STATE",
@@ -692,7 +692,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 37,
         "FIELD_DESCRIPTION": "AUTH ZIP",
@@ -710,7 +710,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 38,
         "FIELD_DESCRIPTION": "CANDIDATE SIGNATURE LAST NAME",
@@ -728,7 +728,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 39,
         "FIELD_DESCRIPTION": "CANDIDATE SIGNATURE FIRST NAME",
@@ -746,7 +746,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 40,
         "FIELD_DESCRIPTION": "CANDIDATE SIGNATURE MIDDLE NAME",
@@ -764,7 +764,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 41,
         "FIELD_DESCRIPTION": "CANDIDATE SIGNATURE PREFIX",
@@ -782,7 +782,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 42,
         "FIELD_DESCRIPTION": "CANDIDATE SIGNATURE SUFFIX",

--- a/schema/backlog/F24.json
+++ b/schema/backlog/F24.json
@@ -22,7 +22,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F24N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -41,7 +41,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -60,7 +60,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [48],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -98,7 +98,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "COMMITTEE NAME",
@@ -116,7 +116,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET 1",
@@ -134,7 +134,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "STREET 2",
@@ -152,7 +152,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "CITY",
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "STATE",
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["20643[1234]"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -226,7 +226,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -245,7 +245,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -264,7 +264,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 15,

--- a/schema/backlog/F2S.json
+++ b/schema/backlog/F2S.json
@@ -14,7 +14,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["F2S"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["S04MA3210"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "AUTH COMMITTEE ID NUMBER",
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "AUTH COMMITTEE NAME",
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "AUTH STREET 1",
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "AUTH STREET 2",
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "AUTH CITY",
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "AUTH STATE",
@@ -160,7 +160,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "AUTH ZIP",

--- a/schema/backlog/F3.json
+++ b/schema/backlog/F3.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -103,7 +103,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -122,7 +122,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -140,7 +140,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -159,7 +159,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -178,7 +178,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -197,7 +197,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -235,7 +235,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["12P"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -254,7 +254,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -292,7 +292,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 22,

--- a/schema/backlog/F3L.json
+++ b/schema/backlog/F3L.json
@@ -34,7 +34,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3LN"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["12P"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -277,7 +277,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -350,7 +350,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -424,7 +424,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -443,7 +443,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -462,7 +462,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -481,7 +481,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -500,7 +500,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 26,

--- a/schema/backlog/F3P.json
+++ b/schema/backlog/F3P.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3PN"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Pat for Pres."],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Oak St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["12P"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -345,7 +345,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -421,7 +421,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 22,

--- a/schema/backlog/F3P31.json
+++ b/schema/backlog/F3P31.json
@@ -25,7 +25,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -44,7 +44,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["AL123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -63,7 +63,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -82,7 +82,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -101,7 +101,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -120,7 +120,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -139,7 +139,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -158,7 +158,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -177,7 +177,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -196,7 +196,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -215,7 +215,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -233,7 +233,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -252,7 +252,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -271,7 +271,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -290,7 +290,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Computer"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 22,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -420,7 +420,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 23,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/F3PS.json
+++ b/schema/backlog/F3PS.json
@@ -19,7 +19,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3PS"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -38,7 +38,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,

--- a/schema/backlog/F3PZ1.json
+++ b/schema/backlog/F3PZ1.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["F3PZ1"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "COMMITTEE NAME (Auth)",

--- a/schema/backlog/F3PZ2.json
+++ b/schema/backlog/F3PZ2.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["F3PZ2"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 3,

--- a/schema/backlog/F3S.json
+++ b/schema/backlog/F3S.json
@@ -19,7 +19,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3S"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -38,7 +38,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,

--- a/schema/backlog/F3X.json
+++ b/schema/backlog/F3X.json
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Foes of Pat"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -103,7 +103,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["125 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -122,7 +122,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -140,7 +140,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -159,7 +159,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -178,7 +178,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -197,7 +197,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["12P"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -216,7 +216,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -253,7 +253,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -322,7 +322,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -360,7 +360,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -379,7 +379,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -398,7 +398,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/backlog/F3Z1.json
+++ b/schema/backlog/F3Z1.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3Z1"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "COMMITTEE NAME (Auth)",

--- a/schema/backlog/F3Z2.json
+++ b/schema/backlog/F3Z2.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F3Z2"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 3,

--- a/schema/backlog/F4.json
+++ b/schema/backlog/F4.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["F4N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["A"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 40,
-      "pattern": "^[ A-Za-z0-9]{0,40}$",
+      "pattern": "^[ -~]{0,40}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "COMMITTEE/ORG TYPE - OTHER DESCRIPTION",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["Q1"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -275,7 +275,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -294,7 +294,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -313,7 +313,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -332,7 +332,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -351,7 +351,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 18,

--- a/schema/backlog/F5.json
+++ b/schema/backlog/F5.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F5N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C90065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -187,7 +187,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "CHANGE OF ADDRESS",
@@ -224,7 +224,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -243,7 +243,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -299,7 +299,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -318,7 +318,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "INDIVIDUAL OCCUPATION",
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "INDIVIDUAL EMPLOYER",
@@ -354,7 +354,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["Q1"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -502,7 +502,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -521,7 +521,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -540,7 +540,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -559,7 +559,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 29,

--- a/schema/backlog/F56.json
+++ b/schema/backlog/F56.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F56"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C90065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -293,7 +293,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "CONTRIBUTOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 20,

--- a/schema/backlog/F57.json
+++ b/schema/backlog/F57.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F57"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C90065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -113,7 +113,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -132,7 +132,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -151,7 +151,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -284,7 +284,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -303,7 +303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -322,7 +322,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -414,7 +414,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Loan Repayment"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -433,7 +433,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -452,7 +452,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 23,
         "FIELD_DESCRIPTION": "PAYEE CMTTE FEC ID NUMBER",
@@ -470,7 +470,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["S"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -489,7 +489,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -508,7 +508,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -527,7 +527,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -546,7 +546,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -565,7 +565,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -584,7 +584,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 30,
@@ -603,7 +603,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 31,
@@ -622,7 +622,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 32,
@@ -641,7 +641,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [35],
       "fec_spec": {
         "COL_SEQ": 33,

--- a/schema/backlog/F6.json
+++ b/schema/backlog/F6.json
@@ -24,7 +24,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F6N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -43,7 +43,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -81,7 +81,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Friends of Pat"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -100,7 +100,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -119,7 +119,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "STREET  2",
@@ -137,7 +137,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -156,7 +156,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -175,7 +175,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -194,7 +194,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -213,7 +213,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "CANDIDATE LAST NAME",
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "CANDIDATE FIRST NAME",
@@ -249,7 +249,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "CANDIDATE MIDDLE NAME",
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "CANDIDATE PREFIX",
@@ -285,7 +285,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CANDIDATE SUFFIX",
@@ -303,7 +303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -322,7 +322,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -360,7 +360,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 19,
         "FIELD_DESCRIPTION": "SIGNER LAST NAME",
@@ -378,7 +378,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "SIGNER FIRST NAME",
@@ -396,7 +396,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 21,
         "FIELD_DESCRIPTION": "SIGNER MIDDLE NAME",
@@ -414,7 +414,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 22,
         "FIELD_DESCRIPTION": "SIGNER PREFIX",
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 23,
         "FIELD_DESCRIPTION": "SIGNER SUFFIX",

--- a/schema/backlog/F65.json
+++ b/schema/backlog/F65.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F65"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -293,7 +293,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "CONTRIBUTOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 20,

--- a/schema/backlog/F7.json
+++ b/schema/backlog/F7.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F7N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C70065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["125 Sycamore St"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "ORGANIZATION STREET  2",
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [33034],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["C"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["12P"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -240,7 +240,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -350,7 +350,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Treasurer"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/backlog/F76.json
+++ b/schema/backlog/F76.json
@@ -25,7 +25,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F76"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -44,7 +44,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C70065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -63,7 +63,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -82,7 +82,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["DM"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -101,7 +101,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 40,
-      "pattern": "^[ A-Za-z0-9]{0,40}$",
+      "pattern": "^[ -~]{0,40}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "COMMUNICATION TYPE - OTHER DESCRIPTION",
@@ -119,7 +119,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["E"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -174,7 +174,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -193,7 +193,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -211,7 +211,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["S"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -249,7 +249,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "S/O CANDIDATE LAST NAME",
@@ -267,7 +267,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "S/O CANDIDATE FIRST NAME",
@@ -285,7 +285,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "S/O CANDIDATE MIDDLE NAME",
@@ -303,7 +303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "S/O CANDIDATE PREFIX",
@@ -321,7 +321,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "S/O CANDIDATE SUFFIX",
@@ -339,7 +339,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -358,7 +358,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 19,

--- a/schema/backlog/F9.json
+++ b/schema/backlog/F9.json
@@ -42,7 +42,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["F9N"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -61,7 +61,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C30065431"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -80,7 +80,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -99,7 +99,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -118,7 +118,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -137,7 +137,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -156,7 +156,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -175,7 +175,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -194,7 +194,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -229,7 +229,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "STREET 1",
@@ -247,7 +247,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "STREET 2",
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "CITY",
@@ -283,7 +283,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "STATE",
@@ -301,7 +301,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["20643[1234]"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -320,7 +320,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "INDIVIDUAL EMPLOYER",
@@ -338,7 +338,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 17,
         "FIELD_DESCRIPTION": "INDIVIDUAL OCCUPATION",
@@ -432,7 +432,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 40,
-      "pattern": "^[ A-Za-z0-9]{0,40}$",
+      "pattern": "^[ -~]{0,40}$",
       "fec_spec": {
         "COL_SEQ": 22,
         "FIELD_DESCRIPTION": "COMMUNICATION TITLE",
@@ -450,7 +450,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["QNC"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "FILER CODE DESCRIPTION",
@@ -487,7 +487,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -506,7 +506,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -544,7 +544,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -563,7 +563,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -582,7 +582,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 30,
@@ -601,7 +601,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "CUSTODIAN STREET 1",
@@ -619,7 +619,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "CUSTODIAN STREET 2",
@@ -637,7 +637,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "CUSTODIAN CITY",
@@ -655,7 +655,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 34,
         "FIELD_DESCRIPTION": "CUSTODIAN STATE",
@@ -673,7 +673,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 35,
         "FIELD_DESCRIPTION": "CUSTODIAN ZIP",
@@ -691,7 +691,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 36,
         "FIELD_DESCRIPTION": "CUSTODIAN EMPLOYER",
@@ -709,7 +709,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 37,
         "FIELD_DESCRIPTION": "CUSTODIAN OCCUPATION",
@@ -763,7 +763,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -782,7 +782,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -801,7 +801,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 42,
@@ -820,7 +820,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 43,
@@ -839,7 +839,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 44,

--- a/schema/backlog/F91.json
+++ b/schema/backlog/F91.json
@@ -20,7 +20,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F91"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -39,7 +39,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -58,7 +58,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -115,7 +115,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -134,7 +134,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -153,7 +153,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -172,7 +172,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "CONTROLLER STREET 1",
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "CONTROLLER STREET 2",
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "CONTROLLER CITY",
@@ -226,7 +226,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "CONTROLLER STATE",
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "CONTROLLER ZIP",
@@ -262,7 +262,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "CONTROLLER EMPLOYER",
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTROLLER OCCUPATION",

--- a/schema/backlog/F92.json
+++ b/schema/backlog/F92.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F92"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A5613456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F93"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "DONOR STREET  2",
@@ -294,7 +294,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -313,7 +313,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -332,7 +332,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 17,

--- a/schema/backlog/F93.json
+++ b/schema/backlog/F93.json
@@ -34,7 +34,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F93"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -53,7 +53,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -72,7 +72,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B5613456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F92"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -148,7 +148,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -167,7 +167,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -205,7 +205,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -224,7 +224,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -243,7 +243,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -262,7 +262,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -281,7 +281,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -319,7 +319,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -338,7 +338,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -357,7 +357,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -376,7 +376,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 19,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -431,7 +431,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Loan Repayment"],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -450,7 +450,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 24,

--- a/schema/backlog/F94.json
+++ b/schema/backlog/F94.json
@@ -20,7 +20,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F94"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -39,7 +39,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -58,7 +58,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B5614789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["F93"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -115,7 +115,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -134,7 +134,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -153,7 +153,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -172,7 +172,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -191,7 +191,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -229,7 +229,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -286,7 +286,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -305,7 +305,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",

--- a/schema/backlog/F99.json
+++ b/schema/backlog/F99.json
@@ -19,7 +19,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["F99"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -38,7 +38,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -57,7 +57,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 3,
         "FIELD_DESCRIPTION": "COMMITTEE NAME",
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "STREET 1",
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "STREET 2",
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "CITY",
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "STATE",
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "ZIP",
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["MST"],
       "fec_spec": {
         "COL_SEQ": 15,

--- a/schema/backlog/HDR.json
+++ b/schema/backlog/HDR.json
@@ -14,7 +14,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["HDR"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["FEC"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["8.3"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "examples": ["SUPERFILER"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 16,
-      "pattern": "^[ A-Za-z0-9]{0,16}$",
+      "pattern": "^[ -~]{0,16}$",
       "examples": ["1.0"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 16,
-      "pattern": "^[ A-Za-z0-9]{0,16}$",
+      "pattern": "^[ -~]{0,16}$",
       "examples": ["FEC-123467"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "HDRcomment",

--- a/schema/backlog/IK_BC_OUT.json
+++ b/schema/backlog/IK_BC_OUT.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -148,7 +148,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -268,7 +268,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -308,7 +308,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_BC_OUT"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/IK_BC_REC.json
+++ b/schema/backlog/IK_BC_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -151,7 +151,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -171,7 +171,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -191,7 +191,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -211,7 +211,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -251,7 +251,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -271,7 +271,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -290,7 +290,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -310,7 +310,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -466,7 +466,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -485,7 +485,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_BC_REC"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/IK_OUT.json
+++ b/schema/backlog/IK_OUT.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_OUT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -295,7 +295,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -333,7 +333,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IK_PAC_REC.json
+++ b/schema/backlog/IK_PAC_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IK_PAC__OUT.json
+++ b/schema/backlog/IK_PAC__OUT.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_PAC__OUT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -313,7 +313,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -332,7 +332,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -351,7 +351,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -370,7 +370,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -389,7 +389,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IK_REC.json
+++ b/schema/backlog/IK_REC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IK_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/INDV_REC.json
+++ b/schema/backlog/INDV_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["INDV_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -221,7 +221,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -240,7 +240,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -259,7 +259,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -278,7 +278,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -296,7 +296,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -315,7 +315,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -334,7 +334,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -463,7 +463,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -481,7 +481,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_CAREY.json
+++ b/schema/backlog/IND_CAREY.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_CAREY"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_JF_MEM-2.json
+++ b/schema/backlog/IND_JF_MEM-2.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_JF_MEM-3.json
+++ b/schema/backlog/IND_JF_MEM-3.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_JF_MEM-4.json
+++ b/schema/backlog/IND_JF_MEM-4.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_JF_MEM.json
+++ b/schema/backlog/IND_JF_MEM.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-2.json
+++ b/schema/backlog/IND_RECNT-2.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-3.json
+++ b/schema/backlog/IND_RECNT-3.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-4.json
+++ b/schema/backlog/IND_RECNT-4.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-5.json
+++ b/schema/backlog/IND_RECNT-5.json
@@ -33,7 +33,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -52,7 +52,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -147,7 +147,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -166,7 +166,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -185,7 +185,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -223,7 +223,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -242,7 +242,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -261,7 +261,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -280,7 +280,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -317,7 +317,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -336,7 +336,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -409,7 +409,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-6.json
+++ b/schema/backlog/IND_RECNT-6.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT-7.json
+++ b/schema/backlog/IND_RECNT-7.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/IND_RECNT.json
+++ b/schema/backlog/IND_RECNT.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["IND_RECNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -408,7 +408,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/JF_TRAN-2.json
+++ b/schema/backlog/JF_TRAN-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["JF_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/JF_TRAN-3.json
+++ b/schema/backlog/JF_TRAN-3.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["JF_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/JF_TRAN-4.json
+++ b/schema/backlog/JF_TRAN-4.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["JF_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/JF_TRAN.json
+++ b/schema/backlog/JF_TRAN.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["JF_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LN12_IK_OUT-2.json
+++ b/schema/backlog/LN12_IK_OUT-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -295,7 +295,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -443,7 +443,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LN12_IK_OUT"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/LN12_IK_OUT.json
+++ b/schema/backlog/LN12_IK_OUT.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LN12_IK_OUT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -295,7 +295,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -333,7 +333,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LN12_IK_TRAN-2.json
+++ b/schema/backlog/LN12_IK_TRAN-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LN12_IK_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LN12_IK_TRAN.json
+++ b/schema/backlog/LN12_IK_TRAN.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LN12_IK_TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LN16_REF_FED_CAN.json
+++ b/schema/backlog/LN16_REF_FED_CAN.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LN16_REF_FED_CAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -295,7 +295,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -422,7 +422,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -441,7 +441,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE LAST NAME",
@@ -459,7 +459,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE FIRST NAME",
@@ -477,7 +477,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE MIDDLE NAME",
@@ -495,7 +495,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE PREFIX",
@@ -513,7 +513,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 34,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE SUFFIX",
@@ -531,7 +531,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -550,7 +550,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -587,7 +587,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Middle Organization"],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -606,7 +606,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -624,7 +624,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LOAN_REC-2.json
+++ b/schema/backlog/LOAN_REC-2.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LOAN_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LOAN_REC.json
+++ b/schema/backlog/LOAN_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LOAN_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -294,7 +294,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -313,7 +313,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -332,7 +332,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -405,7 +405,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -423,7 +423,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -441,7 +441,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/LOAN_REP_REC.json
+++ b/schema/backlog/LOAN_REP_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["LOAN_REP_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -277,7 +277,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -296,7 +296,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -333,7 +333,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -352,7 +352,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -443,7 +443,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -461,7 +461,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/OFFSET.json
+++ b/schema/backlog/OFFSET.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["OFFSET"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -277,7 +277,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -296,7 +296,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -333,7 +333,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -352,7 +352,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -443,7 +443,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -461,7 +461,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/OTHER_COM_CAREY.json
+++ b/schema/backlog/OTHER_COM_CAREY.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["OTHER_COM_CAREY"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/OTH_REC.json
+++ b/schema/backlog/OTH_REC.json
@@ -32,7 +32,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["OTH_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -127,7 +127,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -146,7 +146,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -165,7 +165,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -184,7 +184,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -203,7 +203,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -241,7 +241,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -260,7 +260,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -279,7 +279,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -298,7 +298,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -335,7 +335,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -354,7 +354,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -427,7 +427,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -464,7 +464,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -483,7 +483,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -501,7 +501,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_BC_PUR.json
+++ b/schema/backlog/PAC_BC_PUR.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -148,7 +148,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -247,7 +247,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -324,7 +324,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -343,7 +343,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -382,7 +382,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -420,7 +420,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_BC_PUR"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAC_BC_PUR_MEM.json
+++ b/schema/backlog/PAC_BC_PUR_MEM.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -325,7 +325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -344,7 +344,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -421,7 +421,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_BC_PUR_MEM"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAC_IK_BC_OUT.json
+++ b/schema/backlog/PAC_IK_BC_OUT.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -308,7 +308,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_IK_BC_OUT"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAC_IK_BC_REC.json
+++ b/schema/backlog/PAC_IK_BC_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -209,7 +209,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -229,7 +229,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -249,7 +249,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -326,7 +326,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -345,7 +345,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -422,7 +422,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_IK_BC_REC"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAC_JF_MEM-2.json
+++ b/schema/backlog/PAC_JF_MEM-2.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-3.json
+++ b/schema/backlog/PAC_JF_MEM-3.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-4.json
+++ b/schema/backlog/PAC_JF_MEM-4.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-5.json
+++ b/schema/backlog/PAC_JF_MEM-5.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-6.json
+++ b/schema/backlog/PAC_JF_MEM-6.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-7.json
+++ b/schema/backlog/PAC_JF_MEM-7.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM-8.json
+++ b/schema/backlog/PAC_JF_MEM-8.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_JF_MEM.json
+++ b/schema/backlog/PAC_JF_MEM.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RCNT-2.json
+++ b/schema/backlog/PAC_RCNT-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RCNT-3.json
+++ b/schema/backlog/PAC_RCNT-3.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RCNT-4.json
+++ b/schema/backlog/PAC_RCNT-4.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RCNT-5.json
+++ b/schema/backlog/PAC_RCNT-5.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RCNT.json
+++ b/schema/backlog/PAC_RCNT.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_REC-2.json
+++ b/schema/backlog/PAC_REC-2.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_REC-3.json
+++ b/schema/backlog/PAC_REC-3.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_REC.json
+++ b/schema/backlog/PAC_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RET-2.json
+++ b/schema/backlog/PAC_RET-2.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RET"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAC_RET.json
+++ b/schema/backlog/PAC_RET.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAC_RET"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_BC_IK_OUT.json
+++ b/schema/backlog/PAR_BC_IK_OUT.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -148,7 +148,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -306,7 +306,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -326,7 +326,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -405,7 +405,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -424,7 +424,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_BC_IK_OUT"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAR_BC_PUR.json
+++ b/schema/backlog/PAR_BC_PUR.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -108,7 +108,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -128,7 +128,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -148,7 +148,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -247,7 +247,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -324,7 +324,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -343,7 +343,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -362,7 +362,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -382,7 +382,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -420,7 +420,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_BC_PUR"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAR_BC_PUR_MEM.json
+++ b/schema/backlog/PAR_BC_PUR_MEM.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -325,7 +325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -344,7 +344,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -421,7 +421,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_BC_PUR_MEM"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAR_CON.json
+++ b/schema/backlog/PAR_CON.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_CON"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["ORG"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_IK_BC_REC.json
+++ b/schema/backlog/PAR_IK_BC_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -89,7 +89,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -109,7 +109,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -228,7 +228,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -248,7 +248,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -325,7 +325,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -344,7 +344,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -363,7 +363,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -421,7 +421,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_IK_BC_REC"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/PAR_MEMO.json
+++ b/schema/backlog/PAR_MEMO.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_MEMO"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -187,7 +187,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -225,7 +225,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -263,7 +263,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -282,7 +282,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -300,7 +300,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -319,7 +319,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -338,7 +338,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -411,7 +411,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -429,7 +429,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -448,7 +448,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -467,7 +467,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -485,7 +485,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_OUT_IK.json
+++ b/schema/backlog/PAR_OUT_IK.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_OUT_IK"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -350,7 +350,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -369,7 +369,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -388,7 +388,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_REC.json
+++ b/schema/backlog/PAR_REC.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_REC_IK.json
+++ b/schema/backlog/PAR_REC_IK.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_REC_IK"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -220,7 +220,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -239,7 +239,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -331,7 +331,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -367,7 +367,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -386,7 +386,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -404,7 +404,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PAR_RET.json
+++ b/schema/backlog/PAR_RET.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PAR_RET"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_JF_MEM.json
+++ b/schema/backlog/PTY_JF_MEM.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -49,7 +49,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -68,7 +68,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_JF_MEM"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -87,7 +87,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -106,7 +106,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -125,7 +125,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -144,7 +144,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -163,7 +163,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -182,7 +182,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -348,7 +348,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 25,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -366,7 +366,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -385,7 +385,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -403,7 +403,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-2.json
+++ b/schema/backlog/PTY_RCNT-2.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-3.json
+++ b/schema/backlog/PTY_RCNT-3.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-4.json
+++ b/schema/backlog/PTY_RCNT-4.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-5.json
+++ b/schema/backlog/PTY_RCNT-5.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-6.json
+++ b/schema/backlog/PTY_RCNT-6.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT-7.json
+++ b/schema/backlog/PTY_RCNT-7.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/PTY_RCNT.json
+++ b/schema/backlog/PTY_RCNT.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["PTY_RCNT"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -384,7 +384,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -402,7 +402,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/REATT_FROM.json
+++ b/schema/backlog/REATT_FROM.json
@@ -30,7 +30,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -70,7 +70,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -90,7 +90,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -110,7 +110,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -190,7 +190,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -210,7 +210,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -230,7 +230,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -270,7 +270,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -289,7 +289,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -309,7 +309,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -445,7 +445,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -465,7 +465,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -484,7 +484,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -503,7 +503,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["REATT_FROM"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/REATT_TO.json
+++ b/schema/backlog/REATT_TO.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -51,7 +51,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -71,7 +71,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -91,7 +91,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -151,7 +151,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -171,7 +171,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -191,7 +191,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -211,7 +211,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -251,7 +251,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -271,7 +271,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -290,7 +290,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -310,7 +310,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIP",
@@ -426,7 +426,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -446,7 +446,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -466,7 +466,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -485,7 +485,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -504,7 +504,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["REATT_TO"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/REF_NONFED_CAN.json
+++ b/schema/backlog/REF_NONFED_CAN.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["REF_NONFED_CAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -293,7 +293,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 20,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/RET_REC.json
+++ b/schema/backlog/RET_REC.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["RET_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -221,7 +221,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -240,7 +240,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -259,7 +259,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -278,7 +278,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -296,7 +296,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -315,7 +315,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -334,7 +334,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -407,7 +407,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -463,7 +463,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -481,7 +481,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchA.json
+++ b/schema/backlog/SchA.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -294,7 +294,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -313,7 +313,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -332,7 +332,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -351,7 +351,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -370,7 +370,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 19,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -442,7 +442,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 23,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -460,7 +460,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -479,7 +479,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -498,7 +498,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -516,7 +516,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -535,7 +535,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -554,7 +554,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE LAST NAME",
@@ -572,7 +572,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE FIRST NAME",
@@ -590,7 +590,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE MIDDLE NAME",
@@ -608,7 +608,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE PREFIX",
@@ -626,7 +626,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "DONOR CANDIDATE SUFFIX",
@@ -644,7 +644,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -663,7 +663,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -700,7 +700,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Middle Organization"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -719,7 +719,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["45 E Street"],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -738,7 +738,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 39,
         "FIELD_DESCRIPTION": "CONDUIT STREET2",
@@ -756,7 +756,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -775,7 +775,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -794,7 +794,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [10111],
       "fec_spec": {
         "COL_SEQ": 42,
@@ -813,7 +813,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -831,7 +831,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -849,7 +849,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["123xyzABC"],
       "fec_spec": {
         "COL_SEQ": 45,

--- a/schema/backlog/SchB.json
+++ b/schema/backlog/SchB.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB17"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["B123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SB21"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["CCM"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -238,7 +238,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -257,7 +257,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -295,7 +295,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -314,7 +314,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -333,7 +333,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -352,7 +352,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -371,7 +371,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 19,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -463,7 +463,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -501,7 +501,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -520,7 +520,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -539,7 +539,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 28,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE LAST NAME",
@@ -557,7 +557,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE FIRST NAME",
@@ -575,7 +575,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE MIDDLE NAME",
@@ -593,7 +593,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE PREFIX",
@@ -611,7 +611,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "BENEFICIARY CANDIDATE SUFFIX",
@@ -629,7 +629,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 33,
@@ -648,7 +648,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -686,7 +686,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Middle Organization"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -705,7 +705,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["45 E Street"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -724,7 +724,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 38,
         "FIELD_DESCRIPTION": "CONDUIT STREET 2",
@@ -742,7 +742,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 39,
@@ -761,7 +761,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -780,7 +780,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [10111],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -799,7 +799,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 42,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -817,7 +817,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",
@@ -835,7 +835,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["123xyzABC"],
       "fec_spec": {
         "COL_SEQ": 44,

--- a/schema/backlog/SchC.json
+++ b/schema/backlog/SchC.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SC/10"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["13A"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["ORG"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["The Bank of Banks"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -187,7 +187,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -225,7 +225,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["The Bank Tower"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -263,7 +263,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["100 Broadway"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -282,7 +282,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["New York"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -301,7 +301,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["NY"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -320,7 +320,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [10011],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -339,7 +339,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -358,7 +358,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 18,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -449,7 +449,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": ["Whenever"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -468,7 +468,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": [0.0565],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -487,7 +487,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -506,7 +506,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -544,7 +544,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -563,7 +563,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "LENDER CANDIDATE LAST NAME",
@@ -581,7 +581,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "LENDER CANDIDATE FIRST NAME",
@@ -599,7 +599,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "LENDER CANDIDATE MIDDLE NM",
@@ -617,7 +617,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "LENDER CANDIDATE PREFIX",
@@ -635,7 +635,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "LENDER CANDIDATE SUFFIX",
@@ -653,7 +653,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -672,7 +672,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -710,7 +710,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 37,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -728,7 +728,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 38,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchC1.json
+++ b/schema/backlog/SchC1.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SC1/9"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -55,7 +55,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456-001"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["The Bank of Banks"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["The Bank Tower"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["100 Broadway"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -169,7 +169,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["New York"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -188,7 +188,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["NY"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -207,7 +207,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [10011],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": [0.0565],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -282,7 +282,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 15,
-      "pattern": "^[ A-Za-z0-9]{0,15}$",
+      "pattern": "^[ -~]{0,15}$",
       "examples": [20121231],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -301,7 +301,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["N"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -375,7 +375,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -394,7 +394,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -413,7 +413,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["House & Car"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -450,7 +450,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["N"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["N"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -488,7 +488,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 25,
         "FIELD_DESCRIPTION": "E.2  DESC  (Specification of the above)",
@@ -541,7 +541,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 28,
         "FIELD_DESCRIPTION": "E.5 IND/NAME (Account Location)",
@@ -559,7 +559,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "E.6 STREET  1",
@@ -577,7 +577,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "E.7 STREET  2",
@@ -595,7 +595,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "E.8 CITY",
@@ -613,7 +613,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "E.9 STATE",
@@ -631,7 +631,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "E.10 ZIP",
@@ -667,7 +667,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Handshake"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -686,7 +686,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -705,7 +705,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -724,7 +724,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -743,7 +743,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 39,
@@ -762,7 +762,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -800,7 +800,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 42,
@@ -819,7 +819,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 43,
@@ -838,7 +838,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 44,
@@ -857,7 +857,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 45,
@@ -876,7 +876,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 46,
@@ -895,7 +895,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Treasurer"],
       "fec_spec": {
         "COL_SEQ": 47,

--- a/schema/backlog/SchC2.json
+++ b/schema/backlog/SchC2.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SC2/9"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456-001"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "GUARANTOR STREET 2",
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -293,7 +293,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 16,

--- a/schema/backlog/SchD.json
+++ b/schema/backlog/SchD.json
@@ -31,7 +31,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SD10"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -50,7 +50,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -69,7 +69,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["D123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -88,7 +88,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -107,7 +107,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["The Bank of Banks"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -126,7 +126,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -145,7 +145,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -164,7 +164,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -202,7 +202,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -221,7 +221,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["The Bank Tower"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -240,7 +240,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["100 Broadway"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -259,7 +259,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["New York"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -278,7 +278,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["NY"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -297,7 +297,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [10011],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -316,7 +316,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "PURPOSE OF DEBT OR OBLIGATION",

--- a/schema/backlog/SchE.json
+++ b/schema/backlog/SchE.json
@@ -41,7 +41,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SE"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -60,7 +60,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -79,7 +79,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["E123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -98,7 +98,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -117,7 +117,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -136,7 +136,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -155,7 +155,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -174,7 +174,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -193,7 +193,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -212,7 +212,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -231,7 +231,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -250,7 +250,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -269,7 +269,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -288,7 +288,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -307,7 +307,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -326,7 +326,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -345,7 +345,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 5,
-      "pattern": "^[ A-Za-z0-9]{0,5}$",
+      "pattern": "^[ -~]{0,5}$",
       "examples": ["P2012"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "fec_spec": {
         "COL_SEQ": 19,
         "FIELD_DESCRIPTION": "ELECTION OTHER DESCRIPTION",
@@ -475,7 +475,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -494,7 +494,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -513,7 +513,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "PAYEE CMTTE FEC ID NUMBER",
@@ -531,7 +531,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["S"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -550,7 +550,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H04MA3210"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -569,7 +569,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 29,
@@ -588,7 +588,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 30,
@@ -607,7 +607,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 31,
@@ -626,7 +626,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 32,
@@ -645,7 +645,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 33,
@@ -664,7 +664,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -683,7 +683,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": [35],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -702,7 +702,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -721,7 +721,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -740,7 +740,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -759,7 +759,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 39,
@@ -778,7 +778,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -797,7 +797,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -835,7 +835,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -853,7 +853,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchF.json
+++ b/schema/backlog/SchF.json
@@ -36,7 +36,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SF"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -55,7 +55,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -74,7 +74,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["F123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["F123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -131,7 +131,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["Y"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -150,7 +150,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "DESIGNATING COMMITTEE ID NUMBER",
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "DESIGNATING COMMITTEE NAME",
@@ -186,7 +186,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 9,
         "FIELD_DESCRIPTION": "SUBORDINATE COMMITTEE ID NUMBER",
@@ -204,7 +204,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "SUBORDINATE COMMITTEE NAME",
@@ -222,7 +222,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "SUBORDINATE STREET  1",
@@ -240,7 +240,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "SUBORDINATE STREET  2",
@@ -258,7 +258,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "fec_spec": {
         "COL_SEQ": 13,
         "FIELD_DESCRIPTION": "SUBORDINATE CITY",
@@ -276,7 +276,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "fec_spec": {
         "COL_SEQ": 14,
         "FIELD_DESCRIPTION": "SUBORDINATE STATE",
@@ -294,7 +294,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "SUBORDINATE ZIP",
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "fec_spec": {
         "COL_SEQ": 16,
         "FIELD_DESCRIPTION": "ENTITY TYPE",
@@ -330,7 +330,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -349,7 +349,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -368,7 +368,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 19,
@@ -387,7 +387,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 20,
@@ -406,7 +406,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 21,
@@ -425,7 +425,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 22,
@@ -444,7 +444,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 23,
@@ -463,7 +463,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -482,7 +482,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -501,7 +501,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 26,
@@ -520,7 +520,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -594,7 +594,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 31,
@@ -613,7 +613,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 32,
@@ -632,7 +632,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00654323"],
       "fec_spec": {
         "COL_SEQ": 33,
@@ -651,7 +651,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["H98765431"],
       "fec_spec": {
         "COL_SEQ": 34,
@@ -670,7 +670,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 35,
@@ -689,7 +689,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Patrick"],
       "fec_spec": {
         "COL_SEQ": 36,
@@ -708,7 +708,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["Thomas"],
       "fec_spec": {
         "COL_SEQ": 37,
@@ -727,7 +727,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Mr."],
       "fec_spec": {
         "COL_SEQ": 38,
@@ -746,7 +746,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr."],
       "fec_spec": {
         "COL_SEQ": 39,
@@ -765,7 +765,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["H"],
       "fec_spec": {
         "COL_SEQ": 40,
@@ -784,7 +784,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["FL"],
       "fec_spec": {
         "COL_SEQ": 41,
@@ -822,7 +822,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 43,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -840,7 +840,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchH1.json
+++ b/schema/backlog/SchH1.json
@@ -18,7 +18,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H1"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H11234-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "State and Local Party Committee Presidential-Only Election Year (28% Federal)",
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "State and Local Party Committee Presidential and Senate Election Year (36% Federal)",
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "State and Local Party Committee Senate-Only Election Year (21% Federal)",
@@ -129,7 +129,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "State and Local Party Committee Non-Presidential and Non-Senate Election Year (15% Federal)",
@@ -183,7 +183,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 10,
         "FIELD_DESCRIPTION": "ADMINISTRATIVE RATIO APPLIES",
@@ -201,7 +201,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "GENERIC VOTER DRIVE RATIO APPLIES",
@@ -219,7 +219,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 12,
         "FIELD_DESCRIPTION": "PUBLIC COMMUNICATIONS REFERENCING PARTY ONLY RATIO APPLIES",

--- a/schema/backlog/SchH2.json
+++ b/schema/backlog/SchH2.json
@@ -18,7 +18,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H2"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H21234-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "ACTIVITY/EVENT NAME",
@@ -93,7 +93,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -112,7 +112,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "YES/NO  (Direct Candidate Support?)",
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["N"],
       "fec_spec": {
         "COL_SEQ": 7,

--- a/schema/backlog/SchH3.json
+++ b/schema/backlog/SchH3.json
@@ -24,7 +24,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H3"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -43,7 +43,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -62,7 +62,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H21234-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -81,7 +81,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H31234-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -100,7 +100,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "ACCOUNT NAME",
@@ -118,7 +118,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["DF"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -137,7 +137,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 7,
         "FIELD_DESCRIPTION": "EVENT/ACTIVITY ID/NAME",

--- a/schema/backlog/SchH4.json
+++ b/schema/backlog/SchH4.json
@@ -37,7 +37,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H4"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -56,7 +56,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -75,7 +75,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H4.123.456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -94,7 +94,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A.1234.5678"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -113,7 +113,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -132,7 +132,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -151,7 +151,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -170,7 +170,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -189,7 +189,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -208,7 +208,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -227,7 +227,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -246,7 +246,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -265,7 +265,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -284,7 +284,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -303,7 +303,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -322,7 +322,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -341,7 +341,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -360,7 +360,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 18,
         "FIELD_DESCRIPTION": "ACCOUNT/EVENT IDENTIFIER",
@@ -469,7 +469,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -488,7 +488,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -507,7 +507,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is Administrative - Only)",
@@ -525,7 +525,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 27,
@@ -544,7 +544,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 28,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is an Exempt Activity)",
@@ -562,7 +562,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is Generic Voter Drive - Only)",
@@ -580,7 +580,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is Direct Candidate Support)",
@@ -598,7 +598,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is Public Communications {Referring Only to Party} Made by PAC",
@@ -616,7 +616,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 32,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -634,7 +634,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 33,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchH5.json
+++ b/schema/backlog/SchH5.json
@@ -25,7 +25,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H5"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -44,7 +44,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -63,7 +63,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H3123789-1234"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -82,7 +82,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 4,
         "FIELD_DESCRIPTION": "ACCOUNT NAME",

--- a/schema/backlog/SchH6.json
+++ b/schema/backlog/SchH6.json
@@ -35,7 +35,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H6"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -54,7 +54,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -73,7 +73,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H6123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -92,7 +92,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -111,7 +111,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -130,7 +130,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -149,7 +149,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -168,7 +168,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -187,7 +187,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -206,7 +206,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -225,7 +225,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 11,
@@ -244,7 +244,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -263,7 +263,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["Suite 16"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -282,7 +282,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["30 Oak Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -301,7 +301,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Springfield"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -320,7 +320,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["MA"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -339,7 +339,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [1012],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -358,7 +358,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 18,
         "FIELD_DESCRIPTION": "ACCOUNT/EVENT IDENTIFIER",
@@ -467,7 +467,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "examples": ["Repay Loan"],
       "fec_spec": {
         "COL_SEQ": 24,
@@ -486,7 +486,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": [1],
       "fec_spec": {
         "COL_SEQ": 25,
@@ -505,7 +505,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 26,
         "FIELD_DESCRIPTION": "YES/NO  (Activity Is Voter Registration)",
@@ -523,7 +523,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "YES/NO  (Activity GOTV)",
@@ -541,7 +541,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "examples": ["X"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -560,7 +560,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 29,
         "FIELD_DESCRIPTION": "YES/NO  (Activity is Generic Campaign)",
@@ -578,7 +578,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 30,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -596,7 +596,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 31,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/SchL.json
+++ b/schema/backlog/SchL.json
@@ -23,7 +23,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SL"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -42,7 +42,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -61,7 +61,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["L123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -80,7 +80,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["123xyzABC"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -99,7 +99,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "ACCOUNT NAME",

--- a/schema/backlog/ScheduleC2.json
+++ b/schema/backlog/ScheduleC2.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SC2/9"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456-001"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["C123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Smith"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["John"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["W"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Dr"],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 10,
-      "pattern": "^[ A-Za-z0-9]{0,10}$",
+      "pattern": "^[ -~]{0,10}$",
       "examples": ["Jr"],
       "fec_spec": {
         "COL_SEQ": 9,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 10,
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 11,
         "FIELD_DESCRIPTION": "GUARANTOR STREET 2",
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 13,
@@ -274,7 +274,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -293,7 +293,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["XYZ Company"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -312,7 +312,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 38,
-      "pattern": "^[ A-Za-z0-9]{0,38}$",
+      "pattern": "^[ -~]{0,38}$",
       "examples": ["QC Inspector"],
       "fec_spec": {
         "COL_SEQ": 16,

--- a/schema/backlog/TRAN.json
+++ b/schema/backlog/TRAN.json
@@ -28,7 +28,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -47,7 +47,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -66,7 +66,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["TRAN"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -85,7 +85,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -104,7 +104,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -123,7 +123,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -142,7 +142,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -161,7 +161,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["John Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -180,7 +180,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -199,7 +199,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -217,7 +217,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -236,7 +236,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -255,7 +255,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -328,7 +328,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -346,7 +346,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "fec_spec": {
         "COL_SEQ": 27,
         "FIELD_DESCRIPTION": "DONOR COMMITTEE FEC ID",
@@ -364,7 +364,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Action PAC"],
       "fec_spec": {
         "COL_SEQ": 28,
@@ -383,7 +383,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -401,7 +401,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/TRANF_FRM_LEV.json
+++ b/schema/backlog/TRANF_FRM_LEV.json
@@ -26,7 +26,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H5"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -45,7 +45,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -64,7 +64,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["TRANF_FRM_LEV"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -83,7 +83,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H3123789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -102,7 +102,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 5,
         "FIELD_DESCRIPTION": "ACCOUNT NAME",

--- a/schema/backlog/TRANF_FRM_NON.json
+++ b/schema/backlog/TRANF_FRM_NON.json
@@ -25,7 +25,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["H3"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -44,7 +44,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -63,7 +63,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["TRANF_FRM_NON"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -82,7 +82,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H21234-3456"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -101,7 +101,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["H31234-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -120,7 +120,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "ACCOUNT NAME",
@@ -138,7 +138,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["DF"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -157,7 +157,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 90,
-      "pattern": "^[ A-Za-z0-9]{0,90}$",
+      "pattern": "^[ -~]{0,90}$",
       "fec_spec": {
         "COL_SEQ": 8,
         "FIELD_DESCRIPTION": "EVENT/ACTIVITY ID/NAME",

--- a/schema/backlog/TRIB_REC.json
+++ b/schema/backlog/TRIB_REC.json
@@ -29,7 +29,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -48,7 +48,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -67,7 +67,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 12,
-      "pattern": "^[ A-Za-z0-9]{0,12}$",
+      "pattern": "^[ -~]{0,12}$",
       "examples": ["TRIB_REC"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -86,7 +86,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A56123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -105,7 +105,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-1234"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -124,7 +124,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 6,
@@ -143,7 +143,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 3,
-      "pattern": "^[ A-Za-z0-9]{0,3}$",
+      "pattern": "^[ -~]{0,3}$",
       "examples": ["IND"],
       "fec_spec": {
         "COL_SEQ": 7,
@@ -162,7 +162,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 200,
-      "pattern": "^[ A-Za-z0-9]{0,200}$",
+      "pattern": "^[ -~]{0,200}$",
       "examples": ["Jo Smith & Co."],
       "fec_spec": {
         "COL_SEQ": 8,
@@ -181,7 +181,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "examples": ["123 Main Street"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -200,7 +200,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 34,
-      "pattern": "^[ A-Za-z0-9]{0,34}$",
+      "pattern": "^[ -~]{0,34}$",
       "fec_spec": {
         "COL_SEQ": 15,
         "FIELD_DESCRIPTION": "CONTRIBUTOR STREET  2",
@@ -218,7 +218,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 30,
-      "pattern": "^[ A-Za-z0-9]{0,30}$",
+      "pattern": "^[ -~]{0,30}$",
       "examples": ["Anytown"],
       "fec_spec": {
         "COL_SEQ": 16,
@@ -237,7 +237,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 2,
-      "pattern": "^[ A-Za-z0-9]{0,2}$",
+      "pattern": "^[ -~]{0,2}$",
       "examples": ["WA"],
       "fec_spec": {
         "COL_SEQ": 17,
@@ -256,7 +256,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": [981110123],
       "fec_spec": {
         "COL_SEQ": 18,
@@ -329,7 +329,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 24,
         "FIELD_DESCRIPTION": "CONTRIBUTION PURPOSE DESCRIPTION",
@@ -347,7 +347,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 1,
-      "pattern": "^[ A-Za-z0-9]{0,1}$",
+      "pattern": "^[ -~]{0,1}$",
       "fec_spec": {
         "COL_SEQ": 44,
         "FIELD_DESCRIPTION": "MEMO CODE",
@@ -365,7 +365,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 100,
-      "pattern": "^[ A-Za-z0-9]{0,100}$",
+      "pattern": "^[ -~]{0,100}$",
       "fec_spec": {
         "COL_SEQ": 45,
         "FIELD_DESCRIPTION": "MEMO TEXT/DESCRIPTION",

--- a/schema/backlog/Text.json
+++ b/schema/backlog/Text.json
@@ -20,7 +20,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4,
-      "pattern": "^[ A-Za-z0-9]{0,4}$",
+      "pattern": "^[ -~]{0,4}$",
       "examples": ["TEXT"],
       "fec_spec": {
         "COL_SEQ": 1,
@@ -39,7 +39,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 9,
-      "pattern": "^[ A-Za-z0-9]{0,9}$",
+      "pattern": "^[ -~]{0,9}$",
       "examples": ["C00123456"],
       "fec_spec": {
         "COL_SEQ": 2,
@@ -58,7 +58,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["T123456789-3456"],
       "fec_spec": {
         "COL_SEQ": 3,
@@ -77,7 +77,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 20,
-      "pattern": "^[ A-Za-z0-9]{0,20}$",
+      "pattern": "^[ -~]{0,20}$",
       "examples": ["A123456789-6543"],
       "fec_spec": {
         "COL_SEQ": 4,
@@ -96,7 +96,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 8,
-      "pattern": "^[ A-Za-z0-9]{0,8}$",
+      "pattern": "^[ -~]{0,8}$",
       "examples": ["SA11AI"],
       "fec_spec": {
         "COL_SEQ": 5,
@@ -115,7 +115,7 @@
       "type": "string",
       "minLength": 0,
       "maxLength": 4000,
-      "pattern": "^[ A-Za-z0-9]{0,4000}$",
+      "pattern": "^[ -~]{0,4000}$",
       "fec_spec": {
         "COL_SEQ": 6,
         "FIELD_DESCRIPTION": "TEXT4000",


### PR DESCRIPTION
Updated all schema files for this (including backlog per Matt) by global replacing **[ A-Za-z0-9]** with **[ -~]**

A search after for A-Z reveals what I believe to be special cases (that I did not touch) in **F3X.json** and **Contact_Candidate.json**:
![image](https://user-images.githubusercontent.com/104843885/173916768-bc95fd04-abfe-42b0-81c5-a978a64e5b45.png)

Please let me know if these need updating as well. 

I also added positive and negative unit tests for this to contact_individual.json.  Please let me know if you think I should add unit tests elsewhere.  

Finally, I spot checked many of the schema files to make sure everything looked ok.  The only concerns I have really are treasurer_first_name and treasurer_last_name in F3X (I'm assuming these should stay as-is in the schema).

Any suggestions on what forms we should have QA spot-check?