### PR TITLE
Feature/60 code coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ version: 2.1
 orbs:
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@1.2
+  node: circleci/node@5.0.2
 
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
@@ -39,14 +40,21 @@ jobs:
       - store_artifacts:
           path: htmlcov
 
+      - node/install:
+          install-yarn: false
+          node-version: "16.13"
+
+      - node/install-packages:
+          pkg-manager: npm
+
       - run:
           name: Run deno tests, save a coverage report, and save coverage percentage
           command: |
+            curl -fsSL https://deno.land/x/install/install.sh | sh
+            export DENO_INSTALL="/home/circleci/.deno"
+            export PATH="$DENO_INSTALL/bin:$PATH"
             npm test
             deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > cov_profile.lcov
-
-      - store_artifacts:
-          path: cov_profile.lcov
 
       - run:
           name: Compare the actual code coverage to the minimum target coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,17 +81,17 @@ jobs:
       - run:
           name: Compare the actual code coverage to the minimum target coverage
           command: |
-            export NEW_PYTHON_LINES=$(cat htmlcov_js/total_percent.txt | awk '{print $1}' )
-            export NEW_PYTHON_HITS=$(cat htmlcov_js/total_percent.txt | awk '{print $2}' )
-            export NEW_PYTHON_PERCENT=$(cat htmlcov_js/total_percent.txt | awk '{print $3}' )
-            echo python coverage is ${NEW_PYTHON_PERCENT}% ${NEW_PYTHON_HITS}/${NEW_PYTHON_LINES} lines
+            export PYTHON_LINES=$(cat htmlcov_js/total_percent.txt | awk '{print $1}' )
+            export PYTHON_HITS=$(cat htmlcov_js/total_percent.txt | awk '{print $2}' )
+            export PYTHON_PERCENT=$(cat htmlcov_js/total_percent.txt | awk '{print $3}' )
+            echo python coverage is ${PYTHON_PERCENT}% ${PYTHON_HITS}/${PYTHON_LINES} lines
 
-            export NEW_JAVASCRIPT_LINES=$(cat htmlcov_py/total_percent.txt| awk '{print $1}' )
-            export NEW_JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
-            export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
-            echo javascript coverage is ${NEW_JAVASCRIPT_PERCENT}% ${NEW_JAVASCRIPT_HITS}/${NEW_JAVASCRIPT_LINES} lines
+            export JAVASCRIPT_LINES=$(cat htmlcov_py/total_percent.txt| awk '{print $1}' )
+            export JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
+            export JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
+            echo javascript coverage is ${JAVASCRIPT_PERCENT}% ${JAVASCRIPT_HITS}/${JAVASCRIPT_LINES} lines
 
-            export NEW_PERCENT="scale=2 ; (($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES)) * 100" | bc
+            export NEW_PERCENT=${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}'
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
             export NEW_PYTHON_LINES=$(cat pytest.out | grep TOTAL | awk '{print $2}' | grep -oE "[0-9]+" )
             export NEW_PYTHON_HITS=$(($NEW_PYTHON_LINES - $(cat pytest.out | grep TOTAL | awk '{print $3}' | grep -oE "[0-9]+" )))
             export NEW_PYTHON_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
-            echo ${NEW_PYTHON_LINES},${NEW_PYTHON_HITS},${NEW_PYTHON_PERCENT} > htmlcov_py/total_percent.txt
+            echo ${NEW_PYTHON_LINES} ${NEW_PYTHON_HITS} ${NEW_PYTHON_PERCENT} > htmlcov_py/total_percent.txt
             echo Total python code coverage percentage is ${NEW_PYTHON_PERCENT}%
 
       - store_artifacts:
@@ -52,17 +52,27 @@ jobs:
       - run:
           name: Run deno tests, save a coverage report, and save coverage percentage
           command: |
+
             curl -fsSL https://deno.land/x/install/install.sh | sh
             export DENO_INSTALL="/home/circleci/.deno"
             export PATH="$DENO_INSTALL/bin:$PATH"
+
+            LCOV_DIRECTORY=/tmp/cache/lcov
+            mkdir -p $LCOV_DIRECTORY
+            if [[ ! -x "$LCOV_DIRECTORY/lcov" ]]; then
+              curl -OlL https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz
+              tar -xvzf lcov-1.16.tar.gz -C $LCOV_DIRECTORY
+              ls $LCOV_DIRECTORY
+            fi
+
             npm test
             mkdir htmlcov_js
             deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > htmlcov_js/cov_profile.lcov
-            genhtml htmlcov_js/cov_profile.lcov --no-function-coverage --output-directory=htmlcov_js > deno_cov.txt
-            export NEW_JAVASCRIPT_LINES=$(cat pytest.out | grep TOTAL | awk '{print $5}' | grep -oE "[0-9]+" )
-            export NEW_JAVASCRIPT_HITS=$(cat pytest.out | grep TOTAL | awk '{print $3}' | grep -oE "[0-9]+" )
-            export NEW_JAVASCRIPT_PERCENT=${cat deno_cov.txt| grep "lines)" | awk '{print $2}' | grep -oE "[0-9\.]+"}
-            echo ${NEW_JAVASCRIPT_LINES},${NEW_JAVASCRIPT_HITS},${NEW_JAVASCRIPT_PERCENT} > htmlcov_js/total_percent.txt
+            $LCOV_DIRECTORY/lcov-1.16/bin/genhtml htmlcov_js/cov_profile.lcov --no-function-coverage --output-directory=htmlcov_js > deno_cov.txt
+            export NEW_JAVASCRIPT_LINES=$(cat deno_cov.txt | grep "lines)" | awk '{print $5}' | grep -oE "[0-9]+" )
+            export NEW_JAVASCRIPT_HITS=$(cat deno_cov.txt | grep "lines)" | awk '{print $3}' | grep -oE "[0-9]+" )
+            export NEW_JAVASCRIPT_PERCENT=$(cat deno_cov.txt| grep "lines)" | awk '{print $2}' | grep -oE "[0-9\.]+")
+            echo ${NEW_JAVASCRIPT_LINES} ${NEW_JAVASCRIPT_HITS} ${NEW_JAVASCRIPT_PERCENT} > htmlcov_js/total_percent.txt
             echo Total javascript code coverage percentage is ${NEW_JAVASCRIPT_PERCENT}%
 
       - store_artifacts:
@@ -71,8 +81,15 @@ jobs:
       - run:
           name: Compare the actual code coverage to the minimum target coverage
           command: |
-            export NEW_PYTHON_PERCENT=$(cat htmlcov_py/total_percent.txt)
-            export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_js/total_percent.txt)
+            export NEW_PYTHON_LINES=$(cat htmlcov_js/total_percent.txt | awk '{print $1}' )
+            export NEW_PYTHON_HITS=$(cat htmlcov_js/total_percent.txt | awk '{print $2}' )
+            export NEW_PYTHON_PERCENT=$(cat htmlcov_js/total_percent.txt | awk '{print $3}' )
+
+            export NEW_JAVASCRIPT_LINES=$(cat htmlcov_py/total_percent.txt| awk '{print $1}' )
+            export NEW_JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
+            export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
+
+            export NEW_PERCENT = $(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           pip-dependency-file: requirements-all.txt
 
       - run:
-          name: Run tests, save a coverage report, and save coverage percentage
+          name: Run python tests, save a coverage report, and save coverage percentage
           command: |
             pytest --cov=.  --cov-report=xml --cov-report=html --cov-report=term | tee pytest.out
             export NEW_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
@@ -38,6 +38,15 @@ jobs:
 
       - store_artifacts:
           path: htmlcov
+
+      - run:
+          name: Run deno tests, save a coverage report, and save coverage percentage
+          command: |
+            npm test
+            deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > cov_profile.lcov
+
+      - store_artifacts:
+          path: cov_profile.lcov
 
       - run:
           name: Compare the actual code coverage to the minimum target coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,10 +84,12 @@ jobs:
             export NEW_PYTHON_LINES=$(cat htmlcov_js/total_percent.txt | awk '{print $1}' )
             export NEW_PYTHON_HITS=$(cat htmlcov_js/total_percent.txt | awk '{print $2}' )
             export NEW_PYTHON_PERCENT=$(cat htmlcov_js/total_percent.txt | awk '{print $3}' )
+            echo python coverage is ${NEW_PYTHON_PERCENT}% (${NEW_PYTHON_HITS}/${NEW_PYTHON_LINES} lines)
 
             export NEW_JAVASCRIPT_LINES=$(cat htmlcov_py/total_percent.txt| awk '{print $1}' )
             export NEW_JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
             export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
+            echo javascript coverage is ${NEW_JAVASCRIPT_PERCENT}% (${NEW_JAVASCRIPT_HITS}/${NEW_JAVASCRIPT_LINES} lines)
 
             export NEW_PERCENT=$(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             export JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
             echo javascript coverage is ${JAVASCRIPT_PERCENT}% ${JAVASCRIPT_HITS}/${JAVASCRIPT_LINES} lines
 
-            export NEW_PERCENT=$(echo "${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}')
+            export NEW_PERCENT=$(echo "${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.0f", (($1+$2)/($3+$4))*100}')
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
             export NEW_JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
             export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
 
-            export NEW_PERCENT = $(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
+            export NEW_PERCENT=$(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
             echo javascript coverage is ${NEW_JAVASCRIPT_PERCENT}% ${NEW_JAVASCRIPT_HITS}/${NEW_JAVASCRIPT_LINES} lines
 
-            export NEW_PERCENT=$(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
+            export NEW_PERCENT="scale=2 ; (($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES)) * 100" | bc
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             export JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
             echo javascript coverage is ${JAVASCRIPT_PERCENT}% ${JAVASCRIPT_HITS}/${JAVASCRIPT_LINES} lines
 
-            export NEW_PERCENT=${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}'
+            export NEW_PERCENT="${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}'
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,15 @@ jobs:
       - run:
           name: Run python tests, save a coverage report, and save coverage percentage
           command: |
-            pytest --cov=.  --cov-report=xml --cov-report=html --cov-report=term | tee pytest.out
+            pytest --cov=.  --cov-report=xml --cov-report=html:htmlcov_py --cov-report=term | tee pytest.out
+            export NEW_PYTHON_LINES=$(cat pytest.out | grep TOTAL | awk '{print $2}' | grep -oE "[0-9]+" )
+            export NEW_PYTHON_HITS=$(($NEW_PYTHON_LINES - $(cat pytest.out | grep TOTAL | awk '{print $3}' | grep -oE "[0-9]+" )))
             export NEW_PYTHON_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
-            echo ${NEW_PYTHON_PERCENT} > htmlcov/total_percent.txt
+            echo ${NEW_PYTHON_LINES},${NEW_PYTHON_HITS},${NEW_PYTHON_PERCENT} > htmlcov_py/total_percent.txt
             echo Total python code coverage percentage is ${NEW_PYTHON_PERCENT}%
 
       - store_artifacts:
-          path: htmlcov
+          path: htmlcov_py
 
       - node/install:
           install-yarn: false
@@ -54,20 +56,23 @@ jobs:
             export DENO_INSTALL="/home/circleci/.deno"
             export PATH="$DENO_INSTALL/bin:$PATH"
             npm test
-            deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > cov_profile.lcov
-            genhtml cov_profile.lcov --no-function-coverage > deno_cov.txt
+            mkdir htmlcov_js
+            deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > htmlcov_js/cov_profile.lcov
+            genhtml htmlcov_js/cov_profile.lcov --no-function-coverage --output-directory=htmlcov_js > deno_cov.txt
+            export NEW_JAVASCRIPT_LINES=$(cat pytest.out | grep TOTAL | awk '{print $5}' | grep -oE "[0-9]+" )
+            export NEW_JAVASCRIPT_HITS=$(cat pytest.out | grep TOTAL | awk '{print $3}' | grep -oE "[0-9]+" )
             export NEW_JAVASCRIPT_PERCENT=${cat deno_cov.txt| grep "lines)" | awk '{print $2}' | grep -oE "[0-9\.]+"}
-            echo ${NEW_JAVASCRIPT_PERCENT} > cov_profile/total_percent.txt
+            echo ${NEW_JAVASCRIPT_LINES},${NEW_JAVASCRIPT_HITS},${NEW_JAVASCRIPT_PERCENT} > htmlcov_js/total_percent.txt
             echo Total javascript code coverage percentage is ${NEW_JAVASCRIPT_PERCENT}%
 
       - store_artifacts:
-          path: cov_profile
+          path: htmlcov_js
 
       - run:
           name: Compare the actual code coverage to the minimum target coverage
           command: |
-            export NEW_PYTHON_PERCENT=$(cat htmlcov/total_percent.txt)
-            export NEW_JAVASCRIPT_PERCENT=$(cat cov_profile/total_percent.txt)
+            export NEW_PYTHON_PERCENT=$(cat htmlcov_py/total_percent.txt)
+            export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_js/total_percent.txt)
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,9 @@ jobs:
           name: Run python tests, save a coverage report, and save coverage percentage
           command: |
             pytest --cov=.  --cov-report=xml --cov-report=html --cov-report=term | tee pytest.out
-            export NEW_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
-            echo ${NEW_PERCENT} > htmlcov/total_percent.txt
-            echo Total code coverage percentage is ${NEW_PERCENT}%
+            export NEW_PYTHON_PERCENT=$(cat pytest.out | grep TOTAL | awk '{print $4}' | grep -oE "[0-9]+" )
+            echo ${NEW_PYTHON_PERCENT} > htmlcov/total_percent.txt
+            echo Total python code coverage percentage is ${NEW_PYTHON_PERCENT}%
 
       - store_artifacts:
           path: htmlcov
@@ -55,11 +55,19 @@ jobs:
             export PATH="$DENO_INSTALL/bin:$PATH"
             npm test
             deno coverage --include="^file:" --exclude="test\\.(ts|js)|node_modules" cov_profile --lcov > cov_profile.lcov
+            genhtml cov_profile.lcov --no-function-coverage > deno_cov.txt
+            export NEW_JAVASCRIPT_PERCENT=${cat deno_cov.txt| grep "lines)" | awk '{print $2}' | grep -oE "[0-9\.]+"}
+            echo ${NEW_JAVASCRIPT_PERCENT} > cov_profile/total_percent.txt
+            echo Total javascript code coverage percentage is ${NEW_JAVASCRIPT_PERCENT}%
+
+      - store_artifacts:
+          path: cov_profile
 
       - run:
           name: Compare the actual code coverage to the minimum target coverage
           command: |
-            export NEW_PERCENT=$(cat htmlcov/total_percent.txt)
+            export NEW_PYTHON_PERCENT=$(cat htmlcov/total_percent.txt)
+            export NEW_JAVASCRIPT_PERCENT=$(cat cov_profile/total_percent.txt)
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             export JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
             echo javascript coverage is ${JAVASCRIPT_PERCENT}% ${JAVASCRIPT_HITS}/${JAVASCRIPT_LINES} lines
 
-            export NEW_PERCENT="${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}'
+            export NEW_PERCENT=$(echo "${PYTHON_HITS} ${JAVASCRIPT_HITS} ${PYTHON_LINES} ${JAVASCRIPT_LINES}" | awk '{printf  "%.2f", (($1+$2)/($3+$4))*100}')
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%
             if [ "${NEW_PERCENT}" -lt ${MIN_COVERAGE_PERCENT-85} ]; then
               echo The total code coverage percentage of ${NEW_PERCENT}% is below the minimum of ${MIN_COVERAGE_PERCENT-85}%

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,12 +84,12 @@ jobs:
             export NEW_PYTHON_LINES=$(cat htmlcov_js/total_percent.txt | awk '{print $1}' )
             export NEW_PYTHON_HITS=$(cat htmlcov_js/total_percent.txt | awk '{print $2}' )
             export NEW_PYTHON_PERCENT=$(cat htmlcov_js/total_percent.txt | awk '{print $3}' )
-            echo python coverage is ${NEW_PYTHON_PERCENT}% (${NEW_PYTHON_HITS}/${NEW_PYTHON_LINES} lines)
+            echo python coverage is ${NEW_PYTHON_PERCENT}% ${NEW_PYTHON_HITS}/${NEW_PYTHON_LINES} lines
 
             export NEW_JAVASCRIPT_LINES=$(cat htmlcov_py/total_percent.txt| awk '{print $1}' )
             export NEW_JAVASCRIPT_HITS=$(cat htmlcov_py/total_percent.txt| awk '{print $2}' )
             export NEW_JAVASCRIPT_PERCENT=$(cat htmlcov_py/total_percent.txt| awk '{print $3}' )
-            echo javascript coverage is ${NEW_JAVASCRIPT_PERCENT}% (${NEW_JAVASCRIPT_HITS}/${NEW_JAVASCRIPT_LINES} lines)
+            echo javascript coverage is ${NEW_JAVASCRIPT_PERCENT}% ${NEW_JAVASCRIPT_HITS}/${NEW_JAVASCRIPT_LINES} lines
 
             export NEW_PERCENT=$(((($NEW_PYTHON_HITS + $NEW_JAVASCRIPT_HITS) / ($NEW_PYTHON_LINES + $NEW_JAVASCRIPT_LINES) * 100)))
             echo Comparing the current code coverage percentage of ${NEW_PERCENT}% to the target of ${MIN_COVERAGE_PERCENT-85}%

--- a/fecfile_validate_js/src/index.ts
+++ b/fecfile_validate_js/src/index.ts
@@ -6,7 +6,7 @@
  * Tested with spec/index-spec.js
  */
 
-import Ajv, { ErrorObject, ValidateFunction } from 'ajv';
+import Ajv, { ErrorObject, ValidateFunction } from "ajv";
 
 /**
  * Validation error information for a single schema property
@@ -34,11 +34,18 @@ const ajv = new Ajv({ allErrors: true, strictSchema: false });
  * @param {string[]} fieldsToValidate
  * @returns {ValidationError[]} Modified version of Ajv output, empty array if no errors found
  */
-export function validate(schema: any, data: any, fieldsToValidate: string[] = []): ValidationError[] {
+export function validate(
+  schema: any,
+  data: any,
+  fieldsToValidate: string[] = []
+): ValidationError[] {
   const validator: ValidateFunction = ajv.compile(schema);
   const isValid: boolean = validator(data);
   const errors: ValidationError[] = [];
 
+  if (isValid) {
+    console.log("adding test code to cover");
+  }
   if (!isValid && !!validator.errors?.length) {
     validator.errors.forEach((error) => {
       const parsedError = parseError(error);
@@ -58,7 +65,7 @@ export function validate(schema: any, data: any, fieldsToValidate: string[] = []
  */
 function parseError(error: ErrorObject): ValidationError {
   let path = error.instancePath.substring(1);
-  if (error.keyword == 'required') {
+  if (error.keyword == "required") {
     path = error.params.missingProperty;
   }
   return {

--- a/fecfile_validate_js/src/index.ts
+++ b/fecfile_validate_js/src/index.ts
@@ -43,9 +43,6 @@ export function validate(
   const isValid: boolean = validator(data);
   const errors: ValidationError[] = [];
 
-  if (isValid) {
-    console.log("adding test code to cover");
-  }
   if (!isValid && !!validator.errors?.length) {
     validator.errors.forEach((error) => {
       const parsedError = parseError(error);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,6 +10,8 @@ sonar.sources=.
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3
 
+sonar.javascript.lcov.reportPaths=cov_profile.lcov
+
 # Exclude utility script from coverage
 # sonar.coverage.exclusions=**/generate-starter-schema.py
 


### PR DESCRIPTION
Introduces deno code coverage report to circleci.  Uses those numbers with the python numbers to make a combined code coverage.

I had to install deno and lcov to get the total code coverages numbers out of the javascript code

Please, if you know of a cleaner way to do this, I would jump at it.  I am not especially happy with how messy this script turned out