### PR TITLE
[WIP] using json-schema date format instead of pattern

### DIFF
--- a/fecfile_validate_js/src/index.ts
+++ b/fecfile_validate_js/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 import Ajv, { ErrorObject, ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
 
 /**
  * Validation error information for a single schema property
@@ -24,6 +25,7 @@ export type ValidationError = {
 };
 
 const ajv = new Ajv({ allErrors: true, strictSchema: false });
+addFormats(ajv, ["date"]);
 
 /**
  * Takes a schema in JSON format and data object to be validated and returns an
@@ -46,10 +48,7 @@ export function validate(
   if (!isValid && !!validator.errors?.length) {
     validator.errors.forEach((error) => {
       const parsedError = parseError(error);
-      if (
-        !fieldsToValidate.length ||
-        fieldsToValidate.includes(parsedError.path)
-      ) {
+      if (!fieldsToValidate.length || fieldsToValidate.includes(parsedError.path)) {
         errors.push(parsedError);
       }
     });

--- a/fecfile_validate_js/src/index.ts
+++ b/fecfile_validate_js/src/index.ts
@@ -25,7 +25,7 @@ export type ValidationError = {
 };
 
 const ajv = new Ajv({ allErrors: true, strictSchema: false });
-addFormats(ajv, ["date"]);
+addFormats(ajv, { mode: "full" });
 
 /**
  * Takes a schema in JSON format and data object to be validated and returns an

--- a/fecfile_validate_js/tests/f3x.test.ts
+++ b/fecfile_validate_js/tests/f3x.test.ts
@@ -211,6 +211,17 @@ Deno.test({
 });
 
 Deno.test({
+  name: "date_signed should be a date",
+  fn: () => {
+    const thisData = { ...perfectForm_F3X, ...{ date_signed: "this is not a date" } };
+    const result = validate(f3xSchema, thisData);
+    assertEquals(result[0].path, "date_signed");
+    assertEquals(result[0].keyword, "format");
+    assertEquals(result[0].message, 'must match format "date"');
+  },
+});
+
+Deno.test({
   name: "date_signed is required",
   fn: () => {
     const thisData = { ...perfectForm_F3X };

--- a/fecfile_validate_js/tests/f3x.test.ts
+++ b/fecfile_validate_js/tests/f3x.test.ts
@@ -205,8 +205,8 @@ Deno.test({
     const thisData = { ...perfectForm_F3X, ...{ date_signed: "" } };
     const result = validate(f3xSchema, thisData);
     assertEquals(result[0].path, "date_signed");
-    assertEquals(result[0].keyword, "minLength");
-    assertEquals(result[0].message, "must NOT have fewer than 10 characters");
+    assertEquals(result[0].keyword, "format");
+    assertEquals(result[0].message, 'must match format "date"');
   },
 });
 
@@ -218,6 +218,12 @@ Deno.test({
     assertEquals(result[0].path, "date_signed");
     assertEquals(result[0].keyword, "format");
     assertEquals(result[0].message, 'must match format "date"');
+
+    const thatData = { ...perfectForm_F3X, ...{ date_signed: "1234" } };
+    const incompleteResult = validate(f3xSchema, thatData);
+    assertEquals(incompleteResult[0].path, "date_signed");
+    assertEquals(incompleteResult[0].keyword, "format");
+    assertEquals(incompleteResult[0].message, 'must match format "date"');
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "hasInstallScript": true,
       "license": "CC0-1.0",
       "dependencies": {
-        "ajv": "^8.11.0"
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.17.0",
@@ -341,6 +342,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1725,6 +1742,14 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "homepage": "https://github.com/fecgov/fecfile-validate#readme",
   "dependencies": {
-    "ajv": "^8.11.0"
+    "ajv": "^8.11.0",
+    "ajv-formats": "^2.1.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.17.0",

--- a/schema/BUS_LAB_NON_CONT_ACC.json
+++ b/schema/BUS_LAB_NON_CONT_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/BUS_LAB_NON_CONT_ACC.json
+++ b/schema/BUS_LAB_NON_CONT_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_MEMO.json
+++ b/schema/EAR_MEMO.json
@@ -375,7 +375,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_MEMO.json
+++ b/schema/EAR_MEMO.json
@@ -376,7 +376,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/EAR_REC.json
+++ b/schema/EAR_REC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_REC.json
+++ b/schema/EAR_REC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/EAR_REC_CONVEN_ACC.json
+++ b/schema/EAR_REC_CONVEN_ACC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_REC_CONVEN_ACC.json
+++ b/schema/EAR_REC_CONVEN_ACC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/EAR_REC_HQ_ACC.json
+++ b/schema/EAR_REC_HQ_ACC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_REC_HQ_ACC.json
+++ b/schema/EAR_REC_HQ_ACC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/EAR_REC_RECNT_ACC.json
+++ b/schema/EAR_REC_RECNT_ACC.json
@@ -353,7 +353,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/EAR_REC_RECNT_ACC.json
+++ b/schema/EAR_REC_RECNT_ACC.json
@@ -354,7 +354,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/F3X.json
+++ b/schema/F3X.json
@@ -232,7 +232,6 @@
       "title": "DATE OF ELECTION",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
@@ -269,7 +268,6 @@
       "title": "COVERAGE FROM DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
@@ -287,7 +285,6 @@
       "title": "COVERAGE THROUGH DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
@@ -416,7 +413,6 @@
       "title": "DATE SIGNED",
       "description": "",
       "type": "string",
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/F3X.json
+++ b/schema/F3X.json
@@ -233,7 +233,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 12,
@@ -270,7 +270,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 14,
@@ -288,7 +288,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 15,
@@ -417,7 +417,7 @@
       "description": "",
       "type": "string",
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 22,

--- a/schema/INDV_REC.json
+++ b/schema/INDV_REC.json
@@ -343,7 +343,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/INDV_REC.json
+++ b/schema/INDV_REC.json
@@ -344,7 +344,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/IND_NP_CONVEN_ACC.json
+++ b/schema/IND_NP_CONVEN_ACC.json
@@ -353,7 +353,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/IND_NP_CONVEN_ACC.json
+++ b/schema/IND_NP_CONVEN_ACC.json
@@ -354,7 +354,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/IND_NP_HQ_ACC.json
+++ b/schema/IND_NP_HQ_ACC.json
@@ -353,7 +353,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/IND_NP_HQ_ACC.json
+++ b/schema/IND_NP_HQ_ACC.json
@@ -354,7 +354,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/IND_NP_RECNT_ACC.json
+++ b/schema/IND_NP_RECNT_ACC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/IND_NP_RECNT_ACC.json
+++ b/schema/IND_NP_RECNT_ACC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/IND_RECNT_REC.json
+++ b/schema/IND_RECNT_REC.json
@@ -353,7 +353,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/IND_RECNT_REC.json
+++ b/schema/IND_RECNT_REC.json
@@ -354,7 +354,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/IND_REC_NON_CONT_ACC.json
+++ b/schema/IND_REC_NON_CONT_ACC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/IND_REC_NON_CONT_ACC.json
+++ b/schema/IND_REC_NON_CONT_ACC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN.json
+++ b/schema/JF_TRAN.json
@@ -264,7 +264,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN.json
+++ b/schema/JF_TRAN.json
@@ -263,7 +263,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_IND_MEMO.json
+++ b/schema/JF_TRAN_IND_MEMO.json
@@ -353,7 +353,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_IND_MEMO.json
+++ b/schema/JF_TRAN_IND_MEMO.json
@@ -354,7 +354,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_CONVEN_ACC.json
+++ b/schema/JF_TRAN_NP_CONVEN_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_CONVEN_ACC.json
+++ b/schema/JF_TRAN_NP_CONVEN_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_CONVEN_PAC_MEMO.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_HQ_ACC.json
+++ b/schema/JF_TRAN_NP_HQ_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_HQ_ACC.json
+++ b/schema/JF_TRAN_NP_HQ_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_HQ_PAC_MEMO.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_RECNT_ACC.json
+++ b/schema/JF_TRAN_NP_RECNT_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_NP_RECNT_ACC.json
+++ b/schema/JF_TRAN_NP_RECNT_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
+++ b/schema/JF_TRAN_NP_RECNT_PAC_MEMO.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_PAC_MEMO.json
+++ b/schema/JF_TRAN_PAC_MEMO.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_PAC_MEMO.json
+++ b/schema/JF_TRAN_PAC_MEMO.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_PARTY_MEMO.json
+++ b/schema/JF_TRAN_PARTY_MEMO.json
@@ -262,7 +262,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_PARTY_MEMO.json
+++ b/schema/JF_TRAN_PARTY_MEMO.json
@@ -263,7 +263,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/JF_TRAN_TRIB_MEMO.json
+++ b/schema/JF_TRAN_TRIB_MEMO.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/JF_TRAN_TRIB_MEMO.json
+++ b/schema/JF_TRAN_TRIB_MEMO.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/OFFSET_TO_OPEX.json
+++ b/schema/OFFSET_TO_OPEX.json
@@ -360,7 +360,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/OFFSET_TO_OPEX.json
+++ b/schema/OFFSET_TO_OPEX.json
@@ -361,7 +361,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/OTH_CMTE_NON_CONT_ACC.json
+++ b/schema/OTH_CMTE_NON_CONT_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/OTH_CMTE_NON_CONT_ACC.json
+++ b/schema/OTH_CMTE_NON_CONT_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/OTH_REC.json
+++ b/schema/OTH_REC.json
@@ -357,7 +357,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/OTH_REC.json
+++ b/schema/OTH_REC.json
@@ -358,7 +358,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_EAR_MEMO.json
+++ b/schema/PAC_EAR_MEMO.json
@@ -275,7 +275,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_EAR_MEMO.json
+++ b/schema/PAC_EAR_MEMO.json
@@ -276,7 +276,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_EAR_REC.json
+++ b/schema/PAC_EAR_REC.json
@@ -275,7 +275,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_EAR_REC.json
+++ b/schema/PAC_EAR_REC.json
@@ -276,7 +276,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NON_FED_REC.json
+++ b/schema/PAC_NON_FED_REC.json
@@ -273,7 +273,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NON_FED_REC.json
+++ b/schema/PAC_NON_FED_REC.json
@@ -272,7 +272,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_NON_FED_RET.json
+++ b/schema/PAC_NON_FED_RET.json
@@ -273,7 +273,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NON_FED_RET.json
+++ b/schema/PAC_NON_FED_RET.json
@@ -272,7 +272,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_NP_CONVEN_ACC.json
+++ b/schema/PAC_NP_CONVEN_ACC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_NP_CONVEN_ACC.json
+++ b/schema/PAC_NP_CONVEN_ACC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NP_HQ_ACC.json
+++ b/schema/PAC_NP_HQ_ACC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_NP_HQ_ACC.json
+++ b/schema/PAC_NP_HQ_ACC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NP_RECNT_ACC.json
+++ b/schema/PAC_NP_RECNT_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_NP_RECNT_ACC.json
+++ b/schema/PAC_NP_RECNT_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_REC.json
+++ b/schema/PAC_REC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_REC.json
+++ b/schema/PAC_REC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_RECNT_REC.json
+++ b/schema/PAC_RECNT_REC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PAC_RECNT_REC.json
+++ b/schema/PAC_RECNT_REC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_RET.json
+++ b/schema/PAC_RET.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PAC_RET.json
+++ b/schema/PAC_RET.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTN_MEMO.json
+++ b/schema/PARTN_MEMO.json
@@ -355,7 +355,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PARTN_MEMO.json
+++ b/schema/PARTN_MEMO.json
@@ -356,7 +356,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTY_NP_RECNT_ACC.json
+++ b/schema/PARTY_NP_RECNT_ACC.json
@@ -352,7 +352,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PARTY_NP_RECNT_ACC.json
+++ b/schema/PARTY_NP_RECNT_ACC.json
@@ -353,7 +353,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTY_REC.json
+++ b/schema/PARTY_REC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PARTY_REC.json
+++ b/schema/PARTY_REC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTY_RECNT_REC.json
+++ b/schema/PARTY_RECNT_REC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTY_RECNT_REC.json
+++ b/schema/PARTY_RECNT_REC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/PARTY_RET.json
+++ b/schema/PARTY_RET.json
@@ -273,7 +273,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/PARTY_RET.json
+++ b/schema/PARTY_RET.json
@@ -272,7 +272,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/REATT_FROM.json
+++ b/schema/REATT_FROM.json
@@ -368,7 +368,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/REATT_FROM.json
+++ b/schema/REATT_FROM.json
@@ -367,7 +367,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/REATT_TO.json
+++ b/schema/REATT_TO.json
@@ -368,7 +368,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/REATT_TO.json
+++ b/schema/REATT_TO.json
@@ -369,7 +369,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/RET_REC.json
+++ b/schema/RET_REC.json
@@ -351,7 +351,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/RET_REC.json
+++ b/schema/RET_REC.json
@@ -352,7 +352,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/SchA.json
+++ b/schema/SchA.json
@@ -386,7 +386,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/SchA.json
+++ b/schema/SchA.json
@@ -387,7 +387,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 20,

--- a/schema/TRAN.json
+++ b/schema/TRAN.json
@@ -265,7 +265,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/TRAN.json
+++ b/schema/TRAN.json
@@ -266,7 +266,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_NP_CONVEN_ACC.json
+++ b/schema/TRIB_NP_CONVEN_ACC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/TRIB_NP_CONVEN_ACC.json
+++ b/schema/TRIB_NP_CONVEN_ACC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_NP_HQ_ACC.json
+++ b/schema/TRIB_NP_HQ_ACC.json
@@ -274,7 +274,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/TRIB_NP_HQ_ACC.json
+++ b/schema/TRIB_NP_HQ_ACC.json
@@ -275,7 +275,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_NP_RECNT_ACC.json
+++ b/schema/TRIB_NP_RECNT_ACC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_NP_RECNT_ACC.json
+++ b/schema/TRIB_NP_RECNT_ACC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/TRIB_REC.json
+++ b/schema/TRIB_REC.json
@@ -268,7 +268,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_REC.json
+++ b/schema/TRIB_REC.json
@@ -267,7 +267,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {

--- a/schema/TRIB_RECNT_REC.json
+++ b/schema/TRIB_RECNT_REC.json
@@ -274,7 +274,7 @@
       "description": "",
       "type": ["string", "null"],
       "minLength": 10,
-      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {
         "COL_SEQ": 21,

--- a/schema/TRIB_RECNT_REC.json
+++ b/schema/TRIB_RECNT_REC.json
@@ -273,7 +273,6 @@
       "title": "CONTRIBUTION DATE",
       "description": "",
       "type": ["string", "null"],
-      "minLength": 10,
       "format": "date",
       "examples": ["2018-11-13"],
       "fec_spec": {


### PR DESCRIPTION
replaces `"pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"` with `"format": "date"`

The boon here is that we get to use things like this

```
const schema = {
  type: "string",
  format: "date",
  formatMinimum: "2016-02-06",
  formatExclusiveMaximum: "2016-12-27",
}
```

You can see in the test I added that it fails validation if the string is not a date.  ~~The issue i'm seeing is that it seems to accept partial dates like "2016" without the month and date.~~ It fails if its ` ""`, too short, or just doesn't match RFC3339