### PR TITLE
Feature/read only memo item jf transfer pac memo

### DIFF
--- a/schema/JF_TRAN_PAC_MEMO.json
+++ b/schema/JF_TRAN_PAC_MEMO.json
@@ -397,6 +397,7 @@
                 "boolean",
                 "null"
             ],
+	    "const": true,
             "fec_spec": {
                 "FIELD_DESCRIPTION": "MEMO CODE",
                 "TYPE": "A/N-1",

--- a/schema/JF_TRAN_PAC_MEMO.json
+++ b/schema/JF_TRAN_PAC_MEMO.json
@@ -393,10 +393,6 @@
         "memo_code": {
             "title": "MEMO CODE",
             "description": "",
-            "type": [
-                "boolean",
-                "null"
-            ],
 	    "const": true,
             "fec_spec": {
                 "FIELD_DESCRIPTION": "MEMO CODE",


### PR DESCRIPTION
Updates the JF_TRAN_PAC_MEMO schema to reflect the requirement that such transactions are always memo_items