### PR TITLE
Remove reference to archived image generator repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ finance information. The project code is distributed across these repositories:
 - [fecfile-web-app](https://github.com/fecgov/fecfile-web-app): this is the browser-based front-end developed in Angular
 - [fecfile-web-api](https://github.com/fecgov/fecfile-web-api): RESTful endpoint supporting the front-end
 - [fecfile-validate](https://github.com/fecgov/fecfile-validate): data validation rules and engine
-- [fecfile-image-generator](https://github.com/fecgov/fecfile-image-generator): provides competed FEC forms in PDF format
 
 The FEC validator is designed around the disemination of FEC defined data
 specifications using the [JSON Schema Specification](http://json-schema.org/).


### PR DESCRIPTION
Archived repository: https://github.com/fecgov/fecfile-image-generator

FECfile will use [Web Print](https://efoservices.fec.gov/static/webprint_help.html)